### PR TITLE
Marshal update

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -47,7 +47,11 @@ class Document implements EntityInterface
     {
         if ($data instanceof Result) {
             $this->_result = $data;
+            $id = $data->getId();
             $data = $data->getData();
+            if ($id !== []) {
+                $data['id'] = $id;
+            }
         }
 
         $options += [

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ElasticSearch;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ElasticSearch\Type;
 
 /**
@@ -87,5 +88,41 @@ class Marshaller
             $output[] = $this->one($record, $options);
         }
         return $output;
+    }
+
+    /**
+     * Merges `$data` into `$document`.
+     *
+     * ### Options:
+     *
+     * * fieldList: A whitelist of fields to be assigned to the entity. If not present
+     *   the accessible fields list in the entity will be used.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
+     * data merged in
+     * @param array $data key value list of fields to be merged into the entity
+     * @param array $options List of options.
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function merge(EntityInterface $entity, array $data, array $options = [])
+    {
+        $isNew = $entity->isNew();
+        $key = null;
+
+        if (!$isNew) {
+            $key = $entity->get('id');
+        }
+
+        if (!isset($options['fieldList'])) {
+            $entity->set($data);
+            return $entity;
+        }
+
+        foreach ((array)$options['fieldList'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $entity->set($field, $data[$field]);
+            }
+        }
+        return $entity;
     }
 }

--- a/src/Type.php
+++ b/src/Type.php
@@ -185,7 +185,11 @@ class Type implements RepositoryInterface
         $type = $this->connection()->getIndex()->getType($this->name());
         $result = $type->getDocument($primaryKey, $options);
         $class = $this->entityClass();
-        $document = new $class($result->getData(), [
+
+        $data = $result->getData();
+        $data['id'] = $result->getId();
+
+        $document = new $class($data, [
             'markNew' => false,
             'markClean' => true,
             'useSetters' => false

--- a/src/Type.php
+++ b/src/Type.php
@@ -393,6 +393,8 @@ class Type implements RepositoryInterface
      */
     public function patchEntity(EntityInterface $entity, array $data, array $options = [])
     {
+        $marshaller = $this->marshaller();
+        return $marshaller->merge($entity, $data, $options);
     }
 
     /**
@@ -415,5 +417,7 @@ class Type implements RepositoryInterface
      */
     public function patchEntities($entities, array $data, array $options = [])
     {
+        $marshaller = $this->marshaller();
+        return $marshaller->mergeMany($entity, $data, $options);
     }
 }

--- a/src/Type.php
+++ b/src/Type.php
@@ -306,7 +306,7 @@ class Type implements RepositoryInterface
      * @param array $options A list of options for the object hydration.
      * @return \Cake\Datasource\EntityInterface
      */
-    public function newEntity($data = null, array $options = null)
+    public function newEntity($data = null, array $options = [])
     {
         if ($data === null) {
             $class = $this->entityClass();
@@ -331,7 +331,7 @@ class Type implements RepositoryInterface
      * @param array $options A list of options for the objects hydration.
      * @return array An array of hydrated records.
      */
-    public function newEntities(array $data, array $options = null)
+    public function newEntities(array $data, array $options = [])
     {
         return $this->marshaller()->many($data, $options);
     }

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -16,6 +16,7 @@ namespace Cake\ElasticSearch\Test;
 
 use Cake\ElasticSearch\Datasource\Connection;
 use Cake\ElasticSearch\Type;
+use Cake\ElasticSearch\Document;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -131,5 +132,59 @@ class TypeTest extends TestCase
         $this->assertEquals(['a' => 'b'], $result->toArray());
         $this->assertFalse($result->dirty());
         $this->assertFalse($result->isNew());
+    }
+
+    /**
+     * Test that newEntity is wired up.
+     *
+     * @return void
+     */
+    public function testNewEntity()
+    {
+        $connection = $this->getMock(
+            'Cake\ElasticSearch\Datasource\Connection',
+            ['getIndex']
+        );
+        $type = new Type([
+            'name' => 'articles',
+            'connection' => $connection
+        ]);
+        $data = [
+            'title' => 'A newer title'
+        ];
+        $result = $type->newEntity($data);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertSame($data, $result->toArray());
+    }
+
+    /**
+     * Test that newEntities is wired up.
+     *
+     * @return void
+     */
+    public function testNewEntities()
+    {
+        $connection = $this->getMock(
+            'Cake\ElasticSearch\Datasource\Connection',
+            ['getIndex']
+        );
+        $type = new Type([
+            'name' => 'articles',
+            'connection' => $connection
+        ]);
+        $data = [
+            [
+                'title' => 'A newer title'
+            ],
+            [
+                'title' => 'A second title'
+            ],
+        ];
+        $result = $type->newEntities($data);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result[1]);
+        $this->assertSame($data[0], $result[0]->toArray());
+        $this->assertSame($data[1], $result[1]->toArray());
     }
 }

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -118,18 +118,22 @@ class TypeTest extends TestCase
             ->method('getType')
             ->will($this->returnValue($internalType));
 
-        $document = $this->getMock('Elastica\Document', ['getData']);
+        $document = $this->getMock('Elastica\Document', ['getId', 'getData']);
         $internalType->expects($this->once())
             ->method('getDocument')
             ->with('foo', ['bar' => 'baz'])
             ->will($this->returnValue($document));
 
-        $document->expects($this->once())->method('getData')
+        $document->expects($this->once())
+            ->method('getData')
             ->will($this->returnValue(['a' => 'b']));
+        $document->expects($this->once())
+            ->method('getId')
+            ->will($this->returnValue('foo'));
 
         $result = $type->get('foo', ['bar' => 'baz']);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
-        $this->assertEquals(['a' => 'b'], $result->toArray());
+        $this->assertEquals(['a' => 'b', 'id' => 'foo'], $result->toArray());
         $this->assertFalse($result->dirty());
         $this->assertFalse($result->isNew());
     }


### PR DESCRIPTION
Add basic single entity patching methods to the marshaller. I've also fixed a few small issues around hydrated objects not having their `id` property set.