### PR TITLE
Add embedded documents when reading

### DIFF
--- a/src/Association/EmbedMany.php
+++ b/src/Association/EmbedMany.php
@@ -1,91 +1,14 @@
 <?php
 namespace Cake\ElasticSearch\Association;
 
-use Cake\Core\App;
-use Cake\Utility\Inflector;
+use Cake\ElasticSearch\Association\Embedded;
 
 /**
  * Represents an embedded document that only contains
- * one instance.
+ * multiple instances.
  */
-class EmbedMany
+class EmbedMany extends Embedded
 {
-    protected $alias;
-
-    /**
-     * The class to use for the embeded document.
-     *
-     * @var string
-     */
-    protected $entityClass;
-
-    /**
-     * The property the embedded document is located under.
-     *
-     * @var string
-     */
-    protected $property;
-
-    /**
-     * Constructor
-     *
-     * @param string $alias The alias/name for the embedded document.
-     * @param array $options The options for the embedded document.
-     */
-    public function __construct($alias, $options = [])
-    {
-        $this->alias = $alias;
-        $defaults = [
-            'entityClass',
-            'property'
-        ];
-        foreach ($defaults as $prop) {
-            if (isset($options[$prop])) {
-                $this->{$prop} = $options[$prop];
-            }
-        }
-
-        if (empty($this->entityClass) && strpos($alias, '.')) {
-            $this->entityClass = $alias;
-        }
-    }
-
-    public function property($name = null)
-    {
-        if ($name === null) {
-            if (!$this->property) {
-                $this->property = Inflector::underscore($this->alias);
-            }
-            return $this->property;
-        }
-        $this->property = $name;
-    }
-
-    public function entityClass($name = null)
-    {
-        if ($name === null && !$this->entityClass) {
-            $default = '\Cake\ElasticSearch\Document';
-            $self = get_called_class();
-            $parts = explode('\\', $self);
-
-            if ($self === __CLASS__ || count($parts) < 3) {
-                return $this->entityClass = $default;
-            }
-
-            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
-            $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
-            if (!class_exists($name)) {
-                return $this->entityClass = $default;
-            }
-        }
-
-        if ($name !== null) {
-            $class = App::className($name, 'Model/Document');
-            $this->entityClass = $class;
-        }
-        return $this->entityClass;
-    }
-
     /**
      * Hydrate an instance from the parent documents data.
      *

--- a/src/Association/EmbedMany.php
+++ b/src/Association/EmbedMany.php
@@ -1,10 +1,107 @@
 <?php
 namespace Cake\ElasticSearch\Association;
 
+use Cake\Core\App;
+use Cake\Utility\Inflector;
+
 /**
  * Represents an embedded document that only contains
  * one instance.
  */
 class EmbedMany
 {
+    protected $alias;
+
+    /**
+     * The class to use for the embeded document.
+     *
+     * @var string
+     */
+    protected $entityClass;
+
+    /**
+     * The property the embedded document is located under.
+     *
+     * @var string
+     */
+    protected $property;
+
+    /**
+     * Constructor
+     *
+     * @param string $alias The alias/name for the embedded document.
+     * @param array $options The options for the embedded document.
+     */
+    public function __construct($alias, $options = [])
+    {
+        $this->alias = $alias;
+        $defaults = [
+            'entityClass',
+            'property'
+        ];
+        foreach ($defaults as $prop) {
+            if (isset($options[$prop])) {
+                $this->{$prop} = $options[$prop];
+            }
+        }
+
+        if (empty($this->entityClass) && strpos($alias, '.')) {
+            $this->entityClass = $alias;
+        }
+    }
+
+    public function property($name = null)
+    {
+        if ($name === null) {
+            if (!$this->property) {
+                $this->property = Inflector::underscore($this->alias);
+            }
+            return $this->property;
+        }
+        $this->property = $name;
+    }
+
+    public function entityClass($name = null)
+    {
+        if ($name === null && !$this->entityClass) {
+            $default = '\Cake\ElasticSearch\Document';
+            $self = get_called_class();
+            $parts = explode('\\', $self);
+
+            if ($self === __CLASS__ || count($parts) < 3) {
+                return $this->entityClass = $default;
+            }
+
+            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
+            $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
+            if (!class_exists($name)) {
+                return $this->entityClass = $default;
+            }
+        }
+
+        if ($name !== null) {
+            $class = App::className($name, 'Model/Document');
+            $this->entityClass = $class;
+        }
+        return $this->entityClass;
+    }
+
+    /**
+     * Hydrate an instance from the parent documents data.
+     *
+     * @param array $data The data to use in the embedded document.
+     * @param array $options The options to use in the new document.
+     * @return \Cake\ElasticSearch\Document
+     */
+    public function hydrate(array $data, $options)
+    {
+        $class = $this->entityClass();
+        $out = [];
+        foreach ($data as $row) {
+            if (is_array($row)) {
+                $out[] = new $class($row, $options);
+            }
+        }
+        return $out;
+    }
 }

--- a/src/Association/EmbedMany.php
+++ b/src/Association/EmbedMany.php
@@ -1,0 +1,10 @@
+<?php
+namespace Cake\ElasticSearch\Association;
+
+/**
+ * Represents an embedded document that only contains
+ * one instance.
+ */
+class EmbedMany
+{
+}

--- a/src/Association/EmbedOne.php
+++ b/src/Association/EmbedOne.php
@@ -1,91 +1,14 @@
 <?php
 namespace Cake\ElasticSearch\Association;
 
-use Cake\Core\App;
-use Cake\Utility\Inflector;
+use Cake\ElasticSearch\Association\Embedded;
 
 /**
  * Represents an embedded document that only contains
  * one instance.
  */
-class EmbedOne
+class EmbedOne extends Embedded
 {
-    protected $alias;
-
-    /**
-     * The class to use for the embeded document.
-     *
-     * @var string
-     */
-    protected $entityClass;
-
-    /**
-     * The property the embedded document is located under.
-     *
-     * @var string
-     */
-    protected $property;
-
-    /**
-     * Constructor
-     *
-     * @param string $alias The alias/name for the embedded document.
-     * @param array $options The options for the embedded document.
-     */
-    public function __construct($alias, $options = [])
-    {
-        $this->alias = $alias;
-        $defaults = [
-            'entityClass',
-            'property'
-        ];
-        foreach ($defaults as $prop) {
-            if (isset($options[$prop])) {
-                $this->{$prop} = $options[$prop];
-            }
-        }
-
-        if (empty($this->entityClass) && strpos($alias, '.')) {
-            $this->entityClass = $alias;
-        }
-    }
-
-    public function property($name = null)
-    {
-        if ($name === null) {
-            if (!$this->property) {
-                $this->property = Inflector::underscore($this->alias);
-            }
-            return $this->property;
-        }
-        $this->property = $name;
-    }
-
-    public function entityClass($name = null)
-    {
-        if ($name === null && !$this->entityClass) {
-            $default = '\Cake\ElasticSearch\Document';
-            $self = get_called_class();
-            $parts = explode('\\', $self);
-
-            if ($self === __CLASS__ || count($parts) < 3) {
-                return $this->entityClass = $default;
-            }
-
-            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
-            $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
-            if (!class_exists($name)) {
-                return $this->entityClass = $default;
-            }
-        }
-
-        if ($name !== null) {
-            $class = App::className($name, 'Model/Document');
-            $this->entityClass = $class;
-        }
-        return $this->entityClass;
-    }
-
     /**
      * Hydrate an instance from the parent documents data.
      *

--- a/src/Association/EmbedOne.php
+++ b/src/Association/EmbedOne.php
@@ -1,0 +1,101 @@
+<?php
+namespace Cake\ElasticSearch\Association;
+
+use Cake\Core\App;
+use Cake\Utility\Inflector;
+
+/**
+ * Represents an embedded document that only contains
+ * one instance.
+ */
+class EmbedOne
+{
+    protected $alias;
+
+    /**
+     * The class to use for the embeded document.
+     *
+     * @var string
+     */
+    protected $entityClass;
+
+    /**
+     * The property the embedded document is located under.
+     *
+     * @var string
+     */
+    protected $property;
+
+    /**
+     * Constructor
+     *
+     * @param string $alias The alias/name for the embedded document.
+     * @param array $options The options for the embedded document.
+     */
+    public function __construct($alias, $options = [])
+    {
+        $this->alias = $alias;
+        $defaults = [
+            'entityClass',
+            'property'
+        ];
+        foreach ($defaults as $prop) {
+            if (isset($options[$prop])) {
+                $this->{$prop} = $options[$prop];
+            }
+        }
+
+        if (empty($this->entityClass) && strpos($alias, '.')) {
+            $this->entityClass = $alias;
+        }
+    }
+
+    public function property($name = null)
+    {
+        if ($name === null) {
+            if (!$this->property) {
+                $this->property = Inflector::underscore($this->alias);
+            }
+            return $this->property;
+        }
+        $this->property = $name;
+    }
+
+    public function entityClass($name = null)
+    {
+        if ($name === null && !$this->entityClass) {
+            $default = '\Cake\ElasticSearch\Document';
+            $self = get_called_class();
+            $parts = explode('\\', $self);
+
+            if ($self === __CLASS__ || count($parts) < 3) {
+                return $this->entityClass = $default;
+            }
+
+            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
+            $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
+            if (!class_exists($name)) {
+                return $this->entityClass = $default;
+            }
+        }
+
+        if ($name !== null) {
+            $class = App::className($name, 'Model/Document');
+            $this->entityClass = $class;
+        }
+        return $this->entityClass;
+    }
+
+    /**
+     * Hydrate an instance from the parent documents data.
+     *
+     * @param array $data The data to use in the embedded document.
+     * @param array $options The options to use in the new document.
+     * @return \Cake\ElasticSearch\Document
+     */
+    public function hydrate(array $data, $options)
+    {
+        $class = $this->entityClass();
+        return new $class($data, $options);
+    }
+}

--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -1,0 +1,115 @@
+<?php
+namespace Cake\ElasticSearch\Association;
+
+use Cake\Core\App;
+use Cake\Utility\Inflector;
+
+/**
+ * Represents an embedded document.
+ *
+ * Subclassed for the various kinds of embedded document types.
+ */
+abstract class Embedded
+{
+    /**
+     * The alias this association uses.
+     *
+     * @var string
+     */
+    protected $alias;
+
+    /**
+     * The class to use for the embeded document.
+     *
+     * @var string
+     */
+    protected $entityClass;
+
+    /**
+     * The property the embedded document is located under.
+     *
+     * @var string
+     */
+    protected $property;
+
+    /**
+     * Constructor
+     *
+     * @param string $alias The alias/name for the embedded document.
+     * @param array $options The options for the embedded document.
+     */
+    public function __construct($alias, $options = [])
+    {
+        $this->alias = $alias;
+        $defaults = [
+            'entityClass',
+            'property'
+        ];
+        foreach ($defaults as $prop) {
+            if (isset($options[$prop])) {
+                $this->{$prop} = $options[$prop];
+            }
+        }
+
+        if (empty($this->entityClass) && strpos($alias, '.')) {
+            $this->entityClass = $alias;
+        }
+    }
+
+    /**
+     * Get/set the property this embed is attached to.
+     *
+     * @param string|null $name The property name to set.
+     * @return string The property name.
+     */
+    public function property($name = null)
+    {
+        if ($name === null) {
+            if (!$this->property) {
+                $this->property = Inflector::underscore($this->alias);
+            }
+            return $this->property;
+        }
+        $this->property = $name;
+    }
+
+    /**
+     * Get/set the entity/document class used for this embed.
+     *
+     * @param string|null $name The class name to set.
+     * @return string The class name.
+     */
+    public function entityClass($name = null)
+    {
+        if ($name === null && !$this->entityClass) {
+            $default = '\Cake\ElasticSearch\Document';
+            $self = get_called_class();
+            $parts = explode('\\', $self);
+
+            if ($self === __CLASS__ || count($parts) < 3) {
+                return $this->entityClass = $default;
+            }
+
+            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
+            $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
+            if (!class_exists($name)) {
+                return $this->entityClass = $default;
+            }
+        }
+
+        if ($name !== null) {
+            $class = App::className($name, 'Model/Document');
+            $this->entityClass = $class;
+        }
+        return $this->entityClass;
+    }
+
+    /**
+     * Hydrate instance(s) from the parent documents data.
+     *
+     * @param array $data The data to use in the embedded document.
+     * @param array $options The options to use in the new document.
+     * @return \Cake\ElasticSearch\Document|array
+     */
+    abstract public function hydrate(array $data, $options);
+}

--- a/src/Document.php
+++ b/src/Document.php
@@ -38,7 +38,7 @@ class Document implements EntityInterface
 
     /**
      * Takes either an array or a Result object form a serach and constructs
-     * a document representing an enty in a elastic search type,
+     * a document representing an entity in a elastic search type,
      *
      * @param array|Elastica\Result $data
      * @param array $options

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -33,14 +33,21 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      *
      * @var string
      */
-    protected $_resultSet;
+    protected $resultSet;
 
     /**
      * The full class name of the document class to wrap the results
      *
      * @var \Cake\ElasticSearch\Document
      */
-    protected $_entityClass;
+    protected $entityClass;
+
+    /**
+     * Embedded type references
+     *
+     * @var array
+     */
+    protected $embeds = [];
 
     /**
      * Decorator's constructor
@@ -50,8 +57,12 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function __construct($resultSet, $query)
     {
-        $this->_resultSet = $resultSet;
-        $this->_entityClass = $query->repository()->entityClass();
+        $this->resultSet = $resultSet;
+        $repo = $query->repository();
+        foreach ($repo->embedded() as $embed) {
+            $this->embeds[$embed->property()] = $embed;
+        }
+        $this->entityClass = $repo->entityClass();
         parent::__construct($resultSet);
     }
 
@@ -62,7 +73,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getResults()
     {
-        return $this->_resultSet->getResults();
+        return $this->resultSet->getResults();
     }
 
     /**
@@ -72,7 +83,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function hasSuggests()
     {
-        return $this->_resultSet->hasSuggests();
+        return $this->resultSet->hasSuggests();
     }
 
     /**
@@ -82,7 +93,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
     */
     public function getSuggests()
     {
-        return $this->_resultSet->getSuggests();
+        return $this->resultSet->getSuggests();
     }
 
     /**
@@ -92,7 +103,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function hasFacets()
     {
-        return $this->_resultSet->hasFacets();
+        return $this->resultSet->hasFacets();
     }
 
     /**
@@ -102,7 +113,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getFacets()
     {
-        return $this->_resultSet->getFacets();
+        return $this->resultSet->getFacets();
     }
 
     /**
@@ -112,7 +123,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getAggregations()
     {
-        return $this->_resultSet->getAggregations();
+        return $this->resultSet->getAggregations();
     }
 
     /**
@@ -124,7 +135,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getAggregation($name)
     {
-        return $this->_resultSet->getAggregation($name);
+        return $this->resultSet->getAggregation($name);
     }
 
     /**
@@ -134,7 +145,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getTotalHits()
     {
-        return $this->_resultSet->getTotalHits();
+        return $this->resultSet->getTotalHits();
     }
 
     /**
@@ -144,7 +155,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getMaxScore()
     {
-        return $this->_resultSet->getMaxScore();
+        return $this->resultSet->getMaxScore();
     }
 
     /**
@@ -154,7 +165,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getTotalTime()
     {
-        return $this->_resultSet->getTotalTime();
+        return $this->resultSet->getTotalTime();
     }
 
     /**
@@ -164,7 +175,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function hasTimedOut()
     {
-        return $this->_resultSet->hasTimedOut();
+        return $this->resultSet->hasTimedOut();
     }
 
     /**
@@ -174,7 +185,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getResponse()
     {
-        return $this->_resultSet->getResponse();
+        return $this->resultSet->getResponse();
     }
 
     /**
@@ -184,7 +195,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function getQuery()
     {
-        return $this->_resultSet->getQuery();
+        return $this->resultSet->getQuery();
     }
 
     /**
@@ -194,7 +205,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function count()
     {
-        return $this->_resultSet->count();
+        return $this->resultSet->count();
     }
 
     /**
@@ -204,7 +215,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function countSuggests()
     {
-        return $this->_resultSet->countSuggests();
+        return $this->resultSet->countSuggests();
     }
 
     /**
@@ -214,13 +225,19 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      */
     public function current()
     {
-        $class = $this->_entityClass;
+        $class = $this->entityClass;
         $options = [
             'markClean' => true,
             'useSetters' => false,
             'markNew' => false
         ];
-        $document = new $class($this->_resultSet->current(), $options);
+        $record = $this->resultSet->current();
+        foreach ($this->embeds as $property => $embed) {
+            if (isset($record[$property])) {
+                $record[$property] = $embed->hydrate($record[$property], $options);
+            }
+        }
+        $document = new $class($record, $options);
         return $document;
     }
 }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -231,13 +231,17 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
             'useSetters' => false,
             'markNew' => false
         ];
-        $record = $this->resultSet->current();
+
+        $result = $this->resultSet->current();
+        $data = $result->getData();
+        $data['id'] = $result->getId();
+
         foreach ($this->embeds as $property => $embed) {
-            if (isset($record[$property])) {
-                $record[$property] = $embed->hydrate($record[$property], $options);
+            if (isset($data[$property])) {
+                $data[$property] = $embed->hydrate($data[$property], $options);
             }
         }
-        $document = new $class($record, $options);
+        $document = new $class($data, $options);
         return $document;
     }
 }

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -73,5 +73,23 @@ class ProfilesFixture extends TestFixture
                 'country' => 'Denmark'
             ]
         ],
+        [
+            'id' => '3',
+            'username' => 'sara',
+            'address' => [
+                [
+                    'street' => '456 street',
+                    'city' => 'Copenhagen',
+                    'province' => 'Copenhagen',
+                    'country' => 'Denmark'
+                ],
+                [
+                    'street' => '89 street',
+                    'city' => 'Calgary',
+                    'province' => 'Alberta',
+                    'country' => 'Canada'
+                ]
+            ]
+        ],
     ];
 }

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Test\Fixture;
+
+use Cake\ElasticSearch\TestSuite\TestFixture;
+
+/**
+ * Profile & Address test fixture.
+ */
+class ProfilesFixture extends TestFixture
+{
+    /**
+     * The table/type for this fixture.
+     *
+     * @var string
+     */
+    public $table = 'profiles';
+
+    /**
+     * The mapping data.
+     *
+     * @var array
+     */
+    public $schema = [
+        'id' => ['type' => 'integer'],
+        'username' => ['type' => 'string'],
+        'address' => [
+            'type' => 'nested',
+            'properties' => [
+                'street' => ['type' => 'string'],
+                'city' => ['type' => 'string'],
+                'province' => ['type' => 'string'],
+                'country' => ['type' => 'string'],
+            ]
+        ],
+    ];
+
+    /**
+     * The fixture records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '1',
+            'username' => 'mark',
+            'address' => [
+                'street' => '123 street',
+                'city' => 'Toronto',
+                'province' => 'Ontario',
+                'country' => 'Canada'
+            ]
+        ],
+        [
+            'id' => '2',
+            'username' => 'jose',
+            'address' => [
+                'street' => '456 street',
+                'city' => 'Copenhagen',
+                'province' => 'Copenhagen',
+                'country' => 'Denmark'
+            ]
+        ],
+    ];
+}

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -16,7 +16,7 @@ namespace Cake\ElasticSearch\Test;
 
 use Cake\ElasticSearch\Document;
 use Cake\TestSuite\TestCase;
-use Elatica\Result;
+use Elastica\Result;
 
 /**
  * Tests the Document class

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -61,6 +61,7 @@ class EmbeddedDocumentTest extends TestCase
         $this->type->embedOne('Address');
         $result = $this->type->get(1);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address);
+        $this->assertEquals('123 street', $result->address->street);
     }
 
     /**
@@ -76,4 +77,34 @@ class EmbeddedDocumentTest extends TestCase
         $this->assertCount(1, $rows);
     }
 
+    /**
+     * Test fetching with embedded has many documents.
+     *
+     * @return void
+     */
+    public function testGetWithEmbedMany()
+    {
+        $this->type->embedMany('Address');
+        $result = $this->type->get(3);
+        $this->assertInternalType('array', $result->address);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address[1]);
+    }
+
+    /**
+     * Test fetching with embedded documents.
+     *
+     * @return void
+     */
+    public function testFindWithEmbedMany()
+    {
+        $this->type->embedMany('Address');
+        $result = $this->type->find()->where(['username' => 'sara']);
+        $rows = $result->toArray();
+
+        $this->assertCount(1, $rows);
+        $this->assertInternalType('array', $rows[0]->address);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $rows[0]->address[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $rows[0]->address[1]);
+    }
 }

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -63,4 +63,17 @@ class EmbeddedDocumentTest extends TestCase
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address);
     }
 
+    /**
+     * Test fetching with embedded documents.
+     *
+     * @return void
+     */
+    public function testFindWithEmbedOne()
+    {
+        $this->type->embedOne('Address');
+        $result = $this->type->find()->where(['username' => 'mark']);
+        $rows = $result->toArray();
+        $this->assertCount(1, $rows);
+    }
+
 }

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Test;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ElasticSearch\Datasource\Connection;
+use Cake\ElasticSearch\Document;
+use Cake\ElasticSearch\Type;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests features around embeded documents.
+ *
+ */
+class EmbeddedDocumentTest extends TestCase
+{
+    public $fixtures = ['plugin.cake/elastic_search.profiles'];
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->type = new Type([
+            'name' => 'profiles',
+            'connection' => ConnectionManager::get('test')
+        ]);
+    }
+
+    /**
+     * Test defining 1:1 embedded documents.
+     *
+     * @return void
+     */
+    public function testEmbedOne()
+    {
+        $this->assertNull($this->type->embedOne('Address'));
+        $assocs = $this->type->embedded();
+        $this->assertCount(1, $assocs);
+        $this->assertEquals('\Cake\ElasticSearch\Document', $assocs[0]->entityClass());
+        $this->assertEquals('address', $assocs[0]->property());
+    }
+
+    /**
+     * Test fetching with embedded documents.
+     *
+     * @return void
+     */
+    public function testGetWithEmbedOne()
+    {
+        $this->type->embedOne('Address');
+        $result = $this->type->get(1);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address);
+    }
+
+}

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -64,10 +64,11 @@ class ResultSetTest extends TestCase
     {
         list($resultSet, $elasticaSet) = $resultSets;
         $data = ['foo' => 1, 'bar' => 2];
-        $result = $this->getMock('Elastica\Result', ['getData'], [[]]);
-        $result->expects($this->once())
-            ->method('getData')
+        $result = $this->getMock('Elastica\Result', ['getId', 'getData'], [[]]);
+        $result->method('getData')
             ->will($this->returnValue($data));
+        $result->method('getId')
+            ->will($this->returnValue(99));
 
         $elasticaSet->expects($this->once())
             ->method('current')
@@ -75,7 +76,7 @@ class ResultSetTest extends TestCase
 
         $document = $resultSet->current();
         $this->assertInstanceOf(__NAMESPACE__ . '\MyTestDocument', $document);
-        $this->assertSame($data, $document->toArray());
+        $this->assertSame($data + ['id' => 99], $document->toArray());
         $this->assertFalse($document->dirty());
         $this->assertFalse($document->isNew());
     }

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -48,6 +48,8 @@ class ResultSetTest extends TestCase
         $type->expects($this->once())
             ->method('entityClass')
             ->will($this->returnValue(__NAMESPACE__ . '\MyTestDocument'));
+        $type->method('embedded')
+            ->will($this->returnValue([]));
         return [new ResultSet($elasticaSet, $query), $elasticaSet];
     }
 
@@ -63,11 +65,14 @@ class ResultSetTest extends TestCase
         list($resultSet, $elasticaSet) = $resultSets;
         $data = ['foo' => 1, 'bar' => 2];
         $result = $this->getMock('Elastica\Result', ['getData'], [[]]);
-        $result->expects($this->once())->method('getData')
+        $result->expects($this->once())
+            ->method('getData')
             ->will($this->returnValue($data));
 
-        $elasticaSet->expects($this->once())->method('current')
+        $elasticaSet->expects($this->once())
+            ->method('current')
             ->will($this->returnValue($result));
+
         $document = $resultSet->current();
         $this->assertInstanceOf(__NAMESPACE__ . '\MyTestDocument', $document);
         $this->assertSame($data, $document->toArray());
@@ -93,7 +98,9 @@ class ResultSetTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods($methods)
             ->getMock();
-            $type = $this->getMock('Cake\ElasticSearch\Type');
+        $type = $this->getMock('Cake\ElasticSearch\Type');
+        $type->method('embedded')
+            ->will($this->returnValue([]));
         $query = $this->getMock('Cake\ElasticSearch\Query', [], [$type]);
         $query->expects($this->once())->method('repository')
             ->will($this->returnValue($type));


### PR DESCRIPTION
This adds the concept of embedded documents when reading data out of elastic search. I've intentionally not tried to address writes right now and will do that in a following pull request.

Embedded documents allow you to embed different entity classes to sections of a complex document, giving you more flexibility around how you model data in elasticsearch.

### Open questions

*  Are the names for the methods/classes reasonable and sensical?
* Should we be trying to share any code with the relational ORM?