### PR TITLE
Marshal and save embedded documents

### DIFF
--- a/src/Association/EmbedMany.php
+++ b/src/Association/EmbedMany.php
@@ -27,4 +27,12 @@ class EmbedMany extends Embedded
         }
         return $out;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type()
+    {
+        return static::ONE_TO_MANY;
+    }
 }

--- a/src/Association/EmbedOne.php
+++ b/src/Association/EmbedOne.php
@@ -21,4 +21,12 @@ class EmbedOne extends Embedded
         $class = $this->entityClass();
         return new $class($data, $options);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function type()
+    {
+        return static::ONE_TO_ONE;
+    }
 }

--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -105,6 +105,16 @@ abstract class Embedded
     }
 
     /**
+     * Get the alias for this embed.
+     *
+     * @return string
+     */
+    public function alias()
+    {
+        return $this->alias;
+    }
+
+    /**
      * Hydrate instance(s) from the parent documents data.
      *
      * @param array $data The data to use in the embedded document.

--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -11,8 +11,18 @@ use Cake\Utility\Inflector;
  */
 abstract class Embedded
 {
+    /**
+     * Type name for a single embedded document.
+     *
+     * @var string
+     */
     const ONE_TO_ONE = 'oneToOne';
 
+    /**
+     * Type name for many embedded documents.
+     *
+     * @var string
+     */
     const ONE_TO_MANY = 'oneToMany';
 
     /**

--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -11,6 +11,10 @@ use Cake\Utility\Inflector;
  */
 abstract class Embedded
 {
+    const ONE_TO_ONE = 'oneToOne';
+
+    const ONE_TO_MANY = 'oneToMany';
+
     /**
      * The alias this association uses.
      *
@@ -122,4 +126,13 @@ abstract class Embedded
      * @return \Cake\ElasticSearch\Document|array
      */
     abstract public function hydrate(array $data, $options);
+
+    /**
+     * Get the type of association this is.
+     *
+     * Returns one of the association type constants.
+     *
+     * @return string
+     */
+    abstract public function type();
 }

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -107,7 +107,7 @@ class Marshaller
      * @param array $data The data to marshal
      * @return array|Cake\ElasticSearch\Document Either a document or an array of documents.
      */
-    protected function newNested($embed, $data)
+    protected function newNested(Embedded $embed, array $data)
     {
         $class = $embed->entityClass();
         if ($embed->type() === Embedded::ONE_TO_ONE) {
@@ -115,7 +115,7 @@ class Marshaller
         }
         if ($embed->type() === Embedded::ONE_TO_MANY) {
             $children = [];
-            foreach ((array)$data as $row) {
+            foreach ($data as $row) {
                 if (is_array($row)) {
                     $children[] = new $class($row);
                 }
@@ -132,7 +132,7 @@ class Marshaller
      * @param array $data The data to marshal
      * @return array|Cake\ElasticSearch\Document Either a document or an array of documents.
      */
-    protected function mergeNested($embed, $existing, $data)
+    protected function mergeNested(Embedded $embed, $existing, array $data)
     {
         $class = $embed->entityClass();
         if ($embed->type() === Embedded::ONE_TO_ONE) {

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -200,6 +200,32 @@ class MarshallerTest extends TestCase
     }
 
     /**
+     * test marshalling a simple object.
+     *
+     * @return void
+     */
+    public function testOneRelations()
+    {
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'user' => [
+                'username' => 'mark',
+            ],
+        ];
+        $this->type->embedOne('User');
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->one($data, ['associated' => ['User']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->user);
+        $this->assertSame($data['title'], $result->title);
+        $this->assertSame($data['body'], $result->body);
+        $this->assertSame($data['user']['username'], $result->user->username);
+    }
+
+    /**
      * Test converting multiple objects at once.
      *
      * @return void

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -204,7 +204,7 @@ class MarshallerTest extends TestCase
      *
      * @return void
      */
-    public function testOneRelations()
+    public function testOneEmbeddedOne()
     {
         $data = [
             'title' => 'Testing',
@@ -223,6 +223,45 @@ class MarshallerTest extends TestCase
         $this->assertSame($data['title'], $result->title);
         $this->assertSame($data['body'], $result->body);
         $this->assertSame($data['user']['username'], $result->user->username);
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->one($data);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInternalType('array', $result->user);
+        $this->assertSame($data['title'], $result->title);
+        $this->assertSame($data['body'], $result->body);
+        $this->assertSame($data['user']['username'], $result->user['username']);
+    }
+
+    /**
+     * test marshalling a simple object.
+     *
+     * @return void
+     */
+    public function testOneEmbeddedMany()
+    {
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'comments' => [
+                ['comment' => 'First comment'],
+                ['comment' => 'Second comment'],
+                'bad' => 'data'
+            ],
+        ];
+        $this->type->embedMany('Comments');
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->one($data, ['associated' => ['Comments']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInternalType('array', $result->comments);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[1]);
+        $this->assertTrue($result->isNew());
+        $this->assertTrue($result->comments[0]->isNew());
+        $this->assertTrue($result->comments[1]->isNew());
     }
 
     /**
@@ -372,6 +411,145 @@ class MarshallerTest extends TestCase
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $result = $marshaller->merge($doc, $data);
         $this->assertEquals('Mutated', $result->title);
+    }
+
+    /**
+     * test merge with an embed one
+     *
+     * @return void
+     */
+    public function testMergeEmbeddedOneExisting()
+    {
+        $this->type->embedOne('User');
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'user' => [
+                'username' => 'mark',
+            ],
+        ];
+        $entity = new Document([
+            'title' => 'Old',
+            'user' => new Document(['username' => 'old'], ['markNew' => false])
+        ], ['markNew' => false]);
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->merge($entity, $data, ['associated' => ['User']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->user);
+        $this->assertFalse($result->isNew(), 'Existing doc');
+        $this->assertFalse($result->user->isNew(), 'Existing sub-doc');
+        $this->assertSame($data['title'], $result->title);
+        $this->assertSame($data['body'], $result->body);
+        $this->assertSame($data['user']['username'], $result->user->username);
+    }
+
+    /**
+     * test merge when embedded documents don't exist
+     *
+     * @return void
+     */
+    public function testMergeEmbeddedOneMissing()
+    {
+        $this->type->embedOne('User');
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'user' => [
+                'username' => 'mark',
+            ],
+        ];
+        $entity = new Document([
+            'title' => 'Old',
+        ], ['markNew' => false]);
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->merge($entity, $data, ['associated' => ['User']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->user);
+        $this->assertSame($data['title'], $result->title);
+        $this->assertSame($data['body'], $result->body);
+        $this->assertSame($data['user']['username'], $result->user->username);
+        $this->assertTrue($result->user->isNew(), 'Was missing, should now be new.');
+    }
+
+    /**
+     * test marshalling a simple object.
+     *
+     * @return void
+     */
+    public function testMergeEmbeddedMany()
+    {
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'comments' => [
+                ['comment' => 'First comment'],
+                ['comment' => 'Second comment'],
+                'bad' => 'data'
+            ],
+        ];
+        $this->type->embedMany('Comments');
+
+        $entity = new Document([
+            'title' => 'old',
+            'comments' => [
+                new Document(['comment' => 'old'], ['markNew' => false]),
+                new Document(['comment' => 'old'], ['markNew' => false]),
+            ]
+        ], ['markNew' => false]);
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->merge($entity, $data, ['associated' => ['Comments']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInternalType('array', $result->comments);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[1]);
+        $this->assertFalse($result->comments[0]->isNew());
+        $this->assertFalse($result->comments[1]->isNew());
+    }
+
+    /**
+     * test merge with some sub documents not existing.
+     *
+     * @return void
+     */
+    public function testMergeEmbeddedManySomeMissing()
+    {
+        $data = [
+            'title' => 'Testing',
+            'body' => 'Elastic text',
+            'comments' => [
+                ['comment' => 'First comment'],
+                ['comment' => 'Second comment'],
+                'bad' => 'data'
+            ],
+        ];
+        $entity = new Document([
+            'title' => 'old',
+            'comments' => [
+                new Document(['comment' => 'old'], ['markNew' => false]),
+            ]
+        ], ['markNew' => false]);
+
+        $this->type->embedMany('Comments');
+
+        $marshaller = new Marshaller($this->type);
+        $result = $marshaller->merge($entity, $data, ['associated' => ['Comments']]);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
+        $this->assertInternalType('array', $result->comments);
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[0]);
+        $this->assertSame('First comment', $result->comments[0]->comment);
+        $this->assertFalse($result->comments[0]->isNew());
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->comments[1]);
+        $this->assertSame('Second comment', $result->comments[1]->comment);
+        $this->assertTrue($result->comments[1]->isNew());
     }
 
     /**

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -291,6 +291,51 @@ class TypeTest extends TestCase
     }
 
     /**
+     * Test save with embedded documents.
+     *
+     * @return void
+     */
+    public function testSaveEmbedOne()
+    {
+        $entity = new Document([
+            'title' => 'A brand new article',
+            'body' => 'Some new content',
+            'user' => new Document(['username' => 'sarah'])
+        ]);
+        $this->type->embedOne('User');
+        $this->type->save($entity);
+
+        $compare = $this->type->get($entity->id);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->user);
+        $this->assertEquals('sarah', $compare->user->username);
+    }
+
+    /**
+     * Test save with embedded documents.
+     *
+     * @return void
+     */
+    public function testSaveEmbedMany()
+    {
+        $entity = new Document([
+            'title' => 'A brand new article',
+            'body' => 'Some new content',
+            'comments' => [
+                new Document(['comment' => 'Nice post']),
+                new Document(['comment' => 'Awesome!']),
+            ]
+        ]);
+        $this->type->embedMany('Comments');
+        $this->type->save($entity);
+
+        $compare = $this->type->get($entity->id);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->comments[0]);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->comments[1]);
+        $this->assertEquals('Nice post', $compare->comments[0]->comment);
+        $this->assertEquals('Awesome!', $compare->comments[1]->comment);
+    }
+
+    /**
      * Test deleting a document.
      *
      * @return void


### PR DESCRIPTION
This adds the ability to marshal and save embedded documents. The features are still pretty minimal, but functional. To come in future pull requests:

* Validation for embedded documents.
* Deeply nested embedded documents.

These will likely both end up as dot separated paths, but I've not yet considered what happens in the scenario where there are deeply nested paths with missing branch elements, or how deeply nested structures expand out.