### PR TITLE
Added $alias parameter in alias() method

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -223,7 +223,7 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      *
      * @return string
      */
-    public function alias()
+    public function alias($alias = null)
     {
         return $this->name();
     }


### PR DESCRIPTION
Added $alias parameter as null in the alias() method to be compatibile with RepositoryInterface::alias($alias = NULL)