### PR TITLE
Fix CS errors and a couple typos

### DIFF
--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\ElasticSearch\Datasource;
 
-use Cake\ElasticSearch\Datasource\SchemaCollection;
 use Cake\Database\Log\LoggedQuery;
+use Cake\ElasticSearch\Datasource\SchemaCollection;
 use Elastica\Client;
 use Elastica\Request;
 
@@ -115,7 +115,8 @@ class Connection extends Client
     /**
      * Part of the implicit Connection interface.
      *
-     * @return void
+     * @param bool $enable Whether or not to log queries
+     * @return bool|void
      */
     public function logQueries($enable = null)
     {
@@ -128,7 +129,8 @@ class Connection extends Client
     /**
      * Part of the implicit Connection interface.
      *
-     * @return void
+     * @param callable $callable An anonymous function to be called
+     * @return callable The result of the called function
      */
     public function transactional($callable)
     {

--- a/src/Datasource/MappingSchema.php
+++ b/src/Datasource/MappingSchema.php
@@ -36,6 +36,7 @@ class MappingSchema
     /**
      * Constructor
      *
+     * @param string $name The name of the type of the mapping data
      * @param array $data The mapping data from elasticsearch
      */
     public function __construct($name, array $data)

--- a/src/Datasource/SchemaCollection.php
+++ b/src/Datasource/SchemaCollection.php
@@ -19,6 +19,11 @@ namespace Cake\ElasticSearch\Datasource;
  */
 class SchemaCollection
 {
+    /**
+     * Returns an empty array as a shim for fixtures
+     *
+     * @return array An empty array
+     */
     public function listTables()
     {
         return [];

--- a/src/Document.php
+++ b/src/Document.php
@@ -37,11 +37,13 @@ class Document implements EntityInterface
     protected $_result;
 
     /**
-     * Takes either an array or a Result object form a serach and constructs
+     * Takes either an array or a Result object form a search and constructs
      * a document representing an entity in a elastic search type,
      *
-     * @param array|Elastica\Result $data
-     * @param array $options
+     * @param array|Elastica\Result $data An array or Result object that
+     *  represents an Elasticsearch document
+     * @param array $options An array of options to set the state of the
+     *  document
      */
     public function __construct($data = [], $options = [])
     {

--- a/src/FilterBuilder.php
+++ b/src/FilterBuilder.php
@@ -119,7 +119,7 @@ class FilterBuilder
      * @param string $field The field to compare.
      * @param array|string $location The coordinate from which to compare.
      * @param string $from The initial distance radius.
-     * @param string $top The ending distance radius.
+     * @param string $to The ending distance radius.
      * @return Elastica\Filter\GeoDistanceRange
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-filter.html
      */
@@ -204,7 +204,7 @@ class FilterBuilder
      * @param string $id The ID of the document containing the pre-indexed shape.
      * @param string $type Index type where the pre-indexed shape is.
      * @param string $index Name of the index where the pre-indexed shape is.
-     * @param string The field specified as path containing the pre-indexed shape.
+     * @param string $path The field specified as path containing the pre-indexed shape.
      * @return Elastica\Filter\GeoShapePreIndex
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
      */
@@ -226,7 +226,6 @@ class FilterBuilder
      * @param string $field The field to compare.
      * @param string|array $location Location as coordinates array or geohash string.
      * @param int|string $precision Length of geohash prefix or distance (3, or "50m")
-     * @param string $index Name of the index where the pre-indexed shape is.
      * @param bool $neighbors If true, filters cells next to the given cell.
      * @return Elastica\Filter\GeohashCell
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-filter.html
@@ -335,7 +334,7 @@ class FilterBuilder
     /**
      * Limits the number of documents (per shard) to execute on.
      *
-     * @param integer $limit The maximum number of documents to filter.
+     * @param int $limit The maximum number of documents to filter.
      * @return Elastica\Filter\Limit
      * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-filter.html
      */

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -79,8 +79,7 @@ class Marshaller
 
         foreach ($this->type->embedded() as $embed) {
             $property = $embed->property();
-            if (
-                in_array($embed->alias(), $options['associated']) &&
+            if (in_array($embed->alias(), $options['associated']) &&
                 isset($data[$property])
             ) {
                 $data[$property] = $this->newNested($embed, $data[$property]);
@@ -171,6 +170,7 @@ class Marshaller
      *
      * @param array $data A list of entity data you want converted into objects.
      * @param array $options Options
+     * @return array An array of hydrated entities
      */
     public function many(array $data, array $options = [])
     {
@@ -207,8 +207,7 @@ class Marshaller
 
         foreach ($this->type->embedded() as $embed) {
             $property = $embed->property();
-            if (
-                in_array($embed->alias(), $options['associated']) &&
+            if (in_array($embed->alias(), $options['associated']) &&
                 isset($data[$property])
             ) {
                 $data[$property] = $this->mergeNested($embed, $entity->{$property}, $data[$property]);
@@ -243,8 +242,10 @@ class Marshaller
      * * fieldList: A whitelist of fields to be assigned to the entity. If not present,
      *   the accessible fields list in the entity will be used.
      *
+     * @param array $entities An array of Elasticsearch entities
      * @param array $data A list of entity data you want converted into objects.
      * @param array $options Options
+     * @return array An array of merged entities
      */
     public function mergeMany(array $entities, array $data, array $options = [])
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -69,6 +69,11 @@ class Query implements IteratorAggregate
      */
     protected $_dirty = false;
 
+    /**
+     * Query constructor
+     *
+     * @param \Cake\ElasticSearch\Type $repository The type of document.
+     */
     public function __construct(Type $repository)
     {
         $this->repository($repository);
@@ -84,7 +89,7 @@ class Query implements IteratorAggregate
      * If `true` is passed in the second argument, any previous selections
      * will be overwritten with the list passed in the first argument.
      *
-     * @param array $order The list of fields to select from _source.
+     * @param array $fields The list of fields to select from _source.
      * @param bool $overwrite Whether or not to replace previous selections.
      * @return $this
      */
@@ -292,6 +297,12 @@ class Query implements IteratorAggregate
         return $this->_buildFilter('postFilter', $conditions, $overwrite);
     }
 
+    /**
+     * Method to set the query
+     *
+     * @param array $matcher Set the query parts
+     * @return $this
+     */
     public function query($matcher)
     {
         $this->_parts['query'] = $matcher;
@@ -413,6 +424,11 @@ class Query implements IteratorAggregate
         return $this;
     }
 
+    /**
+     * Executes the query.
+     *
+     * @return Cake\ElasticSearch\ResultSet The results of the query
+     */
     protected function _execute()
     {
         $connection = $this->_repository->connection();
@@ -423,6 +439,11 @@ class Query implements IteratorAggregate
         return new ResultSet($type->search($query), $this);
     }
 
+    /**
+     * Compile the Elasticsearch query.
+     *
+     * @return string The Elasticsearch query.
+     */
     public function compileQuery()
     {
         if ($this->_parts['fields']) {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -60,6 +60,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
      * Decorator's constructor
      *
      * @param \Elastica\ResultSet $resultSet The results from Elastica to wrap
+     * @param \Elastica\Query $query The Elasticsearch Query object
      * @return void
      */
     public function __construct($resultSet, $query)

--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -16,8 +16,8 @@ namespace Cake\ElasticSearch\TestSuite;
 
 use Cake\ElasticSearch\Datasource\Connection;
 use Elastica\Document as ElasticaDocument;
-use Elastica\Type\Mapping as ElasticaMapping;
 use Elastica\Query\MatchAll;
+use Elastica\Type\Mapping as ElasticaMapping;
 
 /**
  * A Test fixture implementation for elastic search.
@@ -63,7 +63,8 @@ class TestFixture
     /**
      * Create the mapping for the type.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
      * @return void
      */
     public function create(Connection $db)
@@ -86,7 +87,8 @@ class TestFixture
     /**
      * Insert fixture documents.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
      * @return void
      */
     public function insert(Connection $db)
@@ -114,7 +116,8 @@ class TestFixture
     /**
      * Drops a mapping and all its related data.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
      * @return void
      */
     public function drop(Connection $db)
@@ -128,7 +131,8 @@ class TestFixture
     /**
      * Truncate the fixture type.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
      * @return void
      */
     public function truncate(Connection $db)

--- a/src/Type.php
+++ b/src/Type.php
@@ -19,8 +19,8 @@ use Cake\Core\App;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Datasource\RulesAwareTrait;
-use Cake\ElasticSearch\Association\EmbedOne;
 use Cake\ElasticSearch\Association\EmbedMany;
+use Cake\ElasticSearch\Association\EmbedOne;
 use Cake\ElasticSearch\Datasource\Connection;
 use Cake\ElasticSearch\Datasource\MappingSchema;
 use Cake\ElasticSearch\Marshaller;
@@ -44,8 +44,8 @@ use InvalidArgumentException;
 class Type implements RepositoryInterface, EventDispatcherInterface
 {
     use EventManagerTrait;
-    use ValidatorAwareTrait;
     use RulesAwareTrait;
+    use ValidatorAwareTrait;
 
     /**
      * Default validator name.
@@ -221,6 +221,7 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      *
      * This method is just an alias of name().
      *
+     * @param string $alias The new type name
      * @return string
      */
     public function alias($alias = null)
@@ -250,8 +251,8 @@ class Type implements RepositoryInterface, EventDispatcherInterface
     /**
      * Returns the query as passed
      *
-     * @param \Cake\ElasticSearch\Query $query
-     * @param array $options
+     * @param \Cake\ElasticSearch\Query $query An Elasticsearch query object
+     * @param array $options An array of options to be used for query logic
      * @return \Cake\ElasticSearch\Query
      */
     public function findAll(Query $query, array $options = [])
@@ -265,7 +266,7 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      *
      * @param string $type name of the finder to be called
      * @param \Cake\ElasticSearch\Query $query The query object to apply the finder options to
-     * @param array $args List of options to pass to the finder
+     * @param array $options List of options to pass to the finder
      * @return \Cake\ElasticSearch\Query
      * @throws \BadMethodCallException
      */
@@ -287,13 +288,16 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      * @{inheritdoc}
      *
      * Any key present in the options array will be translated as a GET argument
-     * when getting the documetn by its id. This is often useful whe you need to
+     * when getting the document by its id. This is often useful whe you need to
      * specify the parent or routing.
      *
      * This method will not trigger the Model.beforeFind callback as it does not use
      * queries for the search, but a faster key lookup to the search index.
      *
+     * @param string $primaryKey The document's primary key
+     * @param array $options An array of options
      * @throws \Elastica\Exception\NotFoundException if no document exist with such id
+     * @return \Cake\ElasticSearch\Document A new Elasticsearch document entity
      */
     public function get($primaryKey, $options = [])
     {
@@ -382,7 +386,7 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      * conditions.
      *
      * @param array $conditions list of conditions to pass to the query
-     * @return boolean
+     * @return bool
      */
     public function exists($conditions)
     {
@@ -409,9 +413,9 @@ class Type implements RepositoryInterface, EventDispatcherInterface
      *
      * - `checkRules` Defaults to true. Check deletion rules before deleting the record.
      *
-     * @param \Cake\Datasource\EntityInterface the entity to be saved
-     * @param array $options
-     * @return \Cake\Datasource\EntityInterface|boolean
+     * @param \Cake\Datasource\EntityInterface $entity The entity to be saved
+     * @param array $options An array of options to be used for the event
+     * @return \Cake\Datasource\EntityInterface|bool
      */
     public function save(EntityInterface $entity, $options = [])
     {

--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -14,16 +14,16 @@
  */
 namespace Cake\ElasticSearch\View\Form;
 
+use Cake\Collection\Collection;
+use Cake\Core\App;
 use Cake\ElasticSearch\Document;
 use Cake\ElasticSearch\Type;
 use Cake\ElasticSearch\TypeRegistry;
-use Cake\Collection\Collection;
-use Cake\Core\App;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
 use Cake\View\Form\ContextInterface;
-use Traversable;
 use RuntimeException;
+use Traversable;
 
 /**
  * Provides a context provider for Elasticsearch documents.

--- a/tests/TestCase/Datasource/ConnectionTest.php
+++ b/tests/TestCase/Datasource/ConnectionTest.php
@@ -21,29 +21,30 @@ use Cake\TestSuite\TestCase;
  * Tests the connection class
  *
  */
-class ConnectionTest extends TestCase {
+class ConnectionTest extends TestCase
+{
 
-/**
- * Tests the getIndex method, in particular, that calling it with no arguments
- * will use the default index for the connection
- *
- * @return void
- */
-	public function testGetIndex() {
-		$connection = new Connection();
-		$index = $connection->getIndex();
-		$this->assertEquals('_all', $index->getName());
+    /**
+     * Tests the getIndex method, in particular, that calling it with no arguments
+     * will use the default index for the connection
+     *
+     * @return void
+     */
+    public function testGetIndex()
+    {
+        $connection = new Connection();
+        $index = $connection->getIndex();
+        $this->assertEquals('_all', $index->getName());
 
-		$connection->setConfigValue('index', 'something_else,another');
-		$index = $connection->getIndex();
-		$this->assertEquals('something_else,another', $index->getName());
+        $connection->setConfigValue('index', 'something_else,another');
+        $index = $connection->getIndex();
+        $this->assertEquals('something_else,another', $index->getName());
 
-		$connection = new Connection(['index' => 'foobar']);
-		$index = $connection->getIndex();
-		$this->assertEquals('foobar', $index->getName());
+        $connection = new Connection(['index' => 'foobar']);
+        $index = $connection->getIndex();
+        $this->assertEquals('foobar', $index->getName());
 
-		$index = $connection->getIndex('baz');
-		$this->assertEquals('baz', $index->getName());
-	}
-
+        $index = $connection->getIndex('baz');
+        $this->assertEquals('baz', $index->getName());
+    }
 }

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -26,7 +26,7 @@ class DocumentTest extends TestCase
 {
 
     /**
-     * Tests constructing a document 
+     * Tests constructing a document
      *
      * @return void
      */

--- a/tests/TestCase/FilterBuilderTest.php
+++ b/tests/TestCase/FilterBuilderTest.php
@@ -520,7 +520,6 @@ class FilterBuilderTest extends TestCase
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
-
     }
 
     /**

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -15,8 +15,8 @@
 namespace Cake\ElasticSearch\Test;
 
 use Cake\Datasource\ConnectionManager;
-use Cake\ElasticSearch\Marshaller;
 use Cake\ElasticSearch\Document;
+use Cake\ElasticSearch\Marshaller;
 use Cake\ElasticSearch\Type;
 use Cake\TestSuite\TestCase;
 
@@ -172,7 +172,8 @@ class MarshallerTest extends TestCase
                 $called++;
                 $this->assertInstanceOf('ArrayObject', $data);
                 $this->assertInstanceOf('ArrayObject', $options);
-            });
+            }
+        );
         $marshaller = new Marshaller($this->type);
         $marshaller->one($data);
 
@@ -384,7 +385,8 @@ class MarshallerTest extends TestCase
                 $called++;
                 $this->assertInstanceOf('ArrayObject', $data);
                 $this->assertInstanceOf('ArrayObject', $options);
-            });
+            }
+        );
         $marshaller = new Marshaller($this->type);
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $marshaller->merge($doc, $data);

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -82,7 +82,7 @@ class QueryTest extends TestCase
 
         $internalType->expects($this->once())
             ->method('search')
-            ->will($this->returnCallback(function($query) use ($result) {
+            ->will($this->returnCallback(function ($query) use ($result) {
                 $this->assertEquals(new \Elastica\Query, $query);
                 return $result;
             }));

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -16,8 +16,8 @@ namespace Cake\ElasticSearch\Test;
 
 use Cake\Datasource\ConnectionManager;
 use Cake\ElasticSearch\Datasource\Connection;
-use Cake\ElasticSearch\Type;
 use Cake\ElasticSearch\Document;
+use Cake\ElasticSearch\Type;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -277,7 +277,8 @@ class TypeTest extends TestCase
                 $called++;
                 $this->assertSame($doc, $entity);
                 $this->assertInstanceOf('ArrayObject', $options);
-            });
+            }
+        );
         $this->type->eventManager()->on(
             'Model.afterSave',
             function ($event, $entity, $options) use ($doc, &$called) {
@@ -286,7 +287,8 @@ class TypeTest extends TestCase
                 $this->assertSame($doc, $entity);
                 $this->assertFalse($doc->isNew(), 'Should not be new');
                 $this->assertFalse($doc->dirty(), 'Should not be dirty');
-            });
+            }
+        );
         $this->type->save($doc);
         $this->assertEquals(2, $called);
     }
@@ -439,14 +441,16 @@ class TypeTest extends TestCase
                 $called++;
                 $this->assertSame($doc, $entity);
                 $this->assertInstanceOf('ArrayObject', $options);
-            });
+            }
+        );
         $this->type->eventManager()->on(
             'Model.afterDelete',
             function ($event, $entity, $options) use ($doc, &$called) {
                 $called++;
                 $this->assertSame($doc, $entity);
                 $this->assertInstanceOf('ArrayObject', $options);
-            });
+            }
+        );
         $this->assertTrue($this->type->delete($doc));
         $this->assertEquals(2, $called);
     }

--- a/tests/init.php
+++ b/tests/init.php
@@ -16,8 +16,8 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 define('APP', __DIR__);
 
-use Cake\Core\Configure;
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 
 Configure::write('App', [


### PR DESCRIPTION
Follows https://github.com/cakephp/elastic-search/pull/39

A couple param/return descriptions are a little generic. Feel free to elaborate.

The remaining errors are protected methods lacking an underscore prefix and the FilterBuilder `and_()` & `or_()` methods not being camel cased. Should we just adjust the protected methods to follow suit for the time being, and update when/if drop that convention as a whole?