### PR TITLE
3.1 Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ services:
 before_script:
   - sleep 7 # Work around elasticsearch startup time.
   - phpenv rehash
+    # Make the index.
+  - curl -XPUT 127.0.0.1:9200/cake_test_db
 
 install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ Assuming you have PHPUnit installed system wide using one of the methods stated
 tests for CakePHP by doing the following:
 
 1. Copy `phpunit.xml.dist` to `phpunit.xml`
-2. Run `phpunit`
+2. Create the test suite index `curl -XPUT 127.0.0.1:9200/cake_test_db`
+3. Run `phpunit`

--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -63,7 +63,7 @@ class Connection extends Client implements ConnectionInterface
      */
     public function schemaCollection()
     {
-        return new SchemaCollection();
+        return new SchemaCollection($this);
     }
 
     /**

--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -14,12 +14,13 @@
  */
 namespace Cake\ElasticSearch\Datasource;
 
+use Cake\Datasource\ConnectionInterface;
 use Cake\Database\Log\LoggedQuery;
 use Cake\ElasticSearch\Datasource\SchemaCollection;
 use Elastica\Client;
 use Elastica\Request;
 
-class Connection extends Client
+class Connection extends Client implements ConnectionInterface
 {
     /**
      * Whether or not query logging is enabled.
@@ -78,45 +79,7 @@ class Connection extends Client
     /**
      * Part of the implicit Connection interface.
      *
-     * @return bool
-     */
-    public function enabled()
-    {
-        return true;
-    }
-
-    /**
-     * Part of the implicit Connection interface.
-     *
      * @return void
-     */
-    public function beginTransaction()
-    {
-    }
-
-    /**
-     * Part of the implicit Connection interface.
-     *
-     * @return void
-     */
-    public function disableForeignKeys()
-    {
-    }
-
-    /**
-     * Part of the implicit Connection interface.
-     *
-     * @return void
-     */
-    public function enableForeignKeys()
-    {
-    }
-
-    /**
-     * Part of the implicit Connection interface.
-     *
-     * @param bool $enable Whether or not to log queries
-     * @return bool|void
      */
     public function logQueries($enable = null)
     {
@@ -129,10 +92,21 @@ class Connection extends Client
     /**
      * Part of the implicit Connection interface.
      *
+     * @param bool $enable Whether or not to log queries
+     * @return bool|void
+     */
+    public function transactional(callable $callable)
+    {
+        return $callable($this);
+    }
+
+    /**
+     * Part of the implicit Connection interface.
+     *
      * @param callable $callable An anonymous function to be called
      * @return callable The result of the called function
      */
-    public function transactional($callable)
+    public function disableConstraints(callable $callable)
     {
         return $callable($this);
     }

--- a/src/Datasource/SchemaCollection.php
+++ b/src/Datasource/SchemaCollection.php
@@ -14,11 +14,30 @@
  */
 namespace Cake\ElasticSearch\Datasource;
 
+use Cake\ElasticSearch\Datasource\Connection;
+
 /**
  * Temporary shim for fixtures as they know too much about databases.
  */
 class SchemaCollection
 {
+    /**
+     * The connection this schema collection is for.
+     *
+     * @var \Cake\ElasticSearch\Datasource\Connection
+     */
+    protected $connection;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\ElasticSearch\Datasource\Connection The connection to use.
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
     /**
      * Returns an empty array as a shim for fixtures
      *
@@ -26,6 +45,8 @@ class SchemaCollection
      */
     public function listTables()
     {
-        return [];
+        $index = $this->connection->getIndex();
+        $result = $index->getMapping();
+        return array_keys($result);
     }
 }

--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -104,10 +104,6 @@ class TestFixture implements FixtureInterface
             return;
         }
         $index = $db->getIndex();
-        if (!$index->exists()) {
-            $index->create();
-        }
-
         $type = $index->getType($this->name);
         $mapping = new ElasticaMapping();
         $mapping->setType($type);

--- a/src/Type.php
+++ b/src/Type.php
@@ -375,7 +375,6 @@ class Type implements RepositoryInterface, EventDispatcherInterface
     {
         $query = $this->query();
         $query->where($conditions);
-        $q = $query->compileQuery();
         $type = $this->connection()->getIndex()->getType($this->name());
         $response = $type->deleteByQuery($query->compileQuery());
         return $response->isOk();

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -26,7 +26,7 @@ class ArticlesFixture extends TestFixture
      *
      * @var string
      */
-    public $table = 'articles';
+    public $name = 'articles';
 
     /**
      * The mapping data.

--- a/tests/Fixture/ProfilesFixture.php
+++ b/tests/Fixture/ProfilesFixture.php
@@ -26,7 +26,7 @@ class ProfilesFixture extends TestFixture
      *
      * @var string
      */
-    public $table = 'profiles';
+    public $name = 'profiles';
 
     /**
      * The mapping data.


### PR DESCRIPTION
Do a bunch of updates related to new features in 3.1

* Use the new interfaces to avoid hinting on specific implementations.
* Remove useless methods in Connection now that there is a small formal interface.
* Actually implement `listTables()`. While a bad name, we don't have a good interface with a more reasonable name.