### PR TITLE
Add missing proxies to work with Crud out of the box

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -486,4 +486,19 @@ class Query implements IteratorAggregate
 
         return $this->_elasticQuery;
     }
+
+    public function aliasField($field)
+    {
+        return [$field];
+    }
+
+    public function alias()
+    {
+        return $this->_repository->alias();
+    }
+
+    public function find($type, $options)
+    {
+        return $this->_repository->find($type, $options);
+    }
 }

--- a/src/Type.php
+++ b/src/Type.php
@@ -680,4 +680,14 @@ class Type implements RepositoryInterface, EventDispatcherInterface
     {
         return 'elastic';
     }
+
+    public function aliasField($field)
+    {
+        return $field;
+    }
+
+    public function primaryKey()
+    {
+        return '_id';
+    }
 }


### PR DESCRIPTION
This is a WIP.

I am not sure that this is the way it should be done in the plugin but when I tried using Crud with ES and pagination, the component kept throwing errors for missing methods at the query level, so I quickly added those (no doc blocks or anything yet).

I am posting this here in the hopes @lorenzo or @markstory help me figure out the best approach (really not sure I am on the right path).
