### PR TITLE
Make sure the Elastica\Result is remembered in Documents

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -48,7 +48,7 @@ class Document implements EntityInterface
     public function __construct($data = [], $options = [])
     {
         if ($data instanceof Result) {
-            $this->_result = $data;
+            $options['result'] = $data;
             $id = $data->getId();
             $data = $data->getData();
             if ($id !== []) {
@@ -61,7 +61,8 @@ class Document implements EntityInterface
             'markClean' => false,
             'markNew' => null,
             'guard' => false,
-            'source' => null
+            'source' => null,
+            'result' => null
         ];
         if (!empty($options['source'])) {
             $this->source($options['source']);
@@ -69,6 +70,10 @@ class Document implements EntityInterface
 
         if ($options['markNew'] !== null) {
             $this->isNew($options['markNew']);
+        }
+
+        if ($options['result'] !== null) {
+            $this->_result = $options['result'];
         }
 
         if (!empty($data) && $options['markClean'] && !$options['useSetters']) {
@@ -86,5 +91,16 @@ class Document implements EntityInterface
         if ($options['markClean']) {
             $this->clean();
         }
+    }
+
+    /**
+     * Returns the Elastica\Result object that can be used for getting
+     * extra information about the document, such as the score and highlights.
+     *
+     * @return \Elastica\Result
+     */
+    public function elasticResult()
+    {
+        return $this->_result;
     }
 }

--- a/src/Document.php
+++ b/src/Document.php
@@ -94,13 +94,67 @@ class Document implements EntityInterface
     }
 
     /**
-     * Returns the Elastica\Result object that can be used for getting
-     * extra information about the document, such as the score and highlights.
+     * Returns the ElasticSearch type name from which this document came from.
      *
-     * @return \Elastica\Result
+     * If this is a new document, this function returns null
+     *
+     * @return string|nulll
      */
-    public function elasticResult()
+    public function type()
     {
-        return $this->_result;
+        if ($this->_result) {
+            return $this->_result->getType();
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the version number of this document as returned by ElasticSearch
+     *
+     * If this is a new document, this function returns 1
+     *
+     * @return int
+     */
+    public function version()
+    {
+        if ($this->_result) {
+            return $this->_result->getVersion();
+        }
+
+        return 1;
+    }
+
+    /**
+     * Returns the highlights array for document as returned by ElasticSearch
+     * for the executed query.
+     *
+     * If this is a new document, or the query used to create it did not ask for
+     * highlights, this function will return an empty array.
+     *
+     * @return array
+     */
+    public function highlights()
+    {
+        if ($this->_result) {
+            return $this->_result->getHighlights();
+        }
+        return [];
+    }
+
+    /**
+     * Returns the explanation array for this document as returned from ElasticSearch.
+     *
+     * If this is a new document, or the query used to create it did not ask for
+     * explanation, this function will return an empty array.
+     *
+     * @return array
+     */
+    public function explanation()
+    {
+        if ($this->_result) {
+            return $this->_result->getExplanation();
+        }
+        return [];
     }
 }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -235,14 +235,15 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
     public function current()
     {
         $class = $this->entityClass;
+        $result = $this->resultSet->current();
         $options = [
             'markClean' => true,
             'useSetters' => false,
             'markNew' => false,
             'source' => $this->repoName,
+            'result' => $result
         ];
 
-        $result = $this->resultSet->current();
         $data = $result->getData();
         $data['id'] = $result->getId();
 

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -51,7 +51,6 @@ class DocumentTest extends TestCase
             ->will($this->returnValue($data));
         $document = new Document($result);
         $this->assertSame($data, $document->toArray());
-        $this->assertSame($result, $document->elasticResult());
     }
 
     /**
@@ -65,6 +64,63 @@ class DocumentTest extends TestCase
         $result = $this->getMock('Elastica\Result', [], [[]]);
         $document = new Document($data, ['result' => $result]);
         $this->assertSame($data, $document->toArray());
-        $this->assertSame($result, $document->elasticResult());
+    }
+
+    /**
+     * Tests that creating a document without a result object will
+     * make the proxy functions return their default
+     *
+     * @return void
+     */
+    public function testNewWithNoResult()
+    {
+        $document = new Document();
+        $this->assertNull($document->type());
+        $this->assertSame(1, $document->version());
+        $this->assertEquals([], $document->highlights());
+        $this->assertEquals([], $document->explanation());
+    }
+
+    /**
+     * Tests that passing a result object in the constructor makes
+     * the proxy the functions return the right value
+     *
+     * @return void
+     */
+    public function testTypeWithResult()
+    {
+        $result = $this->getMock('Elastica\Result', [], [[]]);
+        $data = ['a' => 'b'];
+
+        $result
+            ->method('getData')
+            ->will($this->returnValue($data));
+
+        $result
+            ->method('getId')
+            ->will($this->returnValue(1));
+
+        $result
+            ->method('getType')
+            ->will($this->returnValue('things'));
+
+        $result
+            ->method('getVersion')
+            ->will($this->returnValue(3));
+
+        $result
+            ->method('getHighlights')
+            ->will($this->returnValue(['highlights array']));
+
+        $result
+            ->method('getExplanation')
+            ->will($this->returnValue(['explanation array']));
+
+        $document = new Document($result);
+        $this->assertSame($data + ['id' => 1], $document->toArray());
+        $this->assertEquals('things', $document->type());
+        $this->assertEquals(3, $document->version());
+        $this->assertEquals(['highlights array'], $document->highlights());
+        $this->assertEquals(['explanation array'], $document->explanation());
     }
 }

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -51,5 +51,20 @@ class DocumentTest extends TestCase
             ->will($this->returnValue($data));
         $document = new Document($result);
         $this->assertSame($data, $document->toArray());
+        $this->assertSame($result, $document->elasticResult());
+    }
+
+    /**
+     * Tests that the result object can be passed in the options array
+     *
+     * @return void
+     */
+    public function testConstructorWithResultAsOption()
+    {
+        $data = ['foo' => 1, 'bar' => 2];
+        $result = $this->getMock('Elastica\Result', [], [[]]);
+        $document = new Document($data, ['result' => $result]);
+        $this->assertSame($data, $document->toArray());
+        $this->assertSame($result, $document->elasticResult());
     }
 }

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -79,6 +79,7 @@ class ResultSetTest extends TestCase
         $this->assertSame($data + ['id' => 99], $document->toArray());
         $this->assertFalse($document->dirty());
         $this->assertFalse($document->isNew());
+        $this->assertSame($result, $document->elasticResult());
     }
 
     /**

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -64,11 +64,13 @@ class ResultSetTest extends TestCase
     {
         list($resultSet, $elasticaSet) = $resultSets;
         $data = ['foo' => 1, 'bar' => 2];
-        $result = $this->getMock('Elastica\Result', ['getId', 'getData'], [[]]);
+        $result = $this->getMock('Elastica\Result', ['getId', 'getData', 'getType'], [[]]);
         $result->method('getData')
             ->will($this->returnValue($data));
         $result->method('getId')
             ->will($this->returnValue(99));
+        $result->method('getType')
+            ->will($this->returnValue('things'));
 
         $elasticaSet->expects($this->once())
             ->method('current')
@@ -79,7 +81,7 @@ class ResultSetTest extends TestCase
         $this->assertSame($data + ['id' => 99], $document->toArray());
         $this->assertFalse($document->dirty());
         $this->assertFalse($document->isNew());
-        $this->assertSame($result, $document->elasticResult());
+        $this->assertEquals('things', $document->type());
     }
 
     /**


### PR DESCRIPTION
Having a hold of the `Elastica\Result` inside Documents is pretty important. Without this, it is not possible to access information such as the document score, highlights or the type it came from.