### PR TITLE
Ignore CS for and_ and or_ method names

### DIFF
--- a/src/FilterBuilder.php
+++ b/src/FilterBuilder.php
@@ -604,8 +604,10 @@ class FilterBuilder
      *
      * @return Elastica\Filter\BoolFilter
      */
+    // @codingStandardsIgnoreStart
     public function and_()
     {
+        // @codingStandardsIgnoreEnd
         $filters = func_get_args();
         $bool = $this->bool();
 
@@ -638,8 +640,10 @@ class FilterBuilder
      *
      * @return Elastica\Filter\BoolOr
      */
+    // @codingStandardsIgnoreStart
     public function or_()
     {
+        // @codingStandardsIgnoreEnd
         $filters = func_get_args();
         $or = new Filter\BoolOr();
 


### PR DESCRIPTION
Fixes CS build. Ignore the naming convention standard for these 2 methods. (for now?) Perhaps only until when/if new method names are used.