### PR TITLE
Add the two new methods dealing with foreign key constraints

### DIFF
--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -143,4 +143,28 @@ class TestFixture
         $type->deleteByQuery($query);
         $index->refresh();
     }
+
+    /**
+     * No-op method needed because of the Fixture interface.
+     * Elasticsearch does not deal with foreign key constraints.
+     *
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
+     * @return void
+     */
+    public function createConstraints(Connection $db)
+    {
+    }
+
+    /**
+     * No-op method needed because of the Fixture interface.
+     * Elasticsearch does not deal with foreign key constraints.
+     *
+     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     *  connection
+     * @return void
+     */
+    public function dropConstraints(Connection $db)
+    {
+    }
 }


### PR DESCRIPTION
This methods are called by the FixtureManager in order to add / drop foreign key constraints to the tables.
Since Elasticsearch does not use the concept of foreign key constraints, these methods are no-op

To be merged when /if the refs PR https://github.com/cakephp/cakephp/pull/7503 is merged