### PR TITLE
Make the Connection and Fixtures objects implements the needed interfaces

### DIFF
--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -15,10 +15,11 @@
 namespace Cake\ElasticSearch\Datasource;
 
 use Cake\Database\Log\LoggedQuery;
+use Cake\Datasource\ConnectionInterface;
 use Elastica\Client;
 use Elastica\Request;
 
-class Connection extends Client
+class Connection extends Client implements ConnectionInterface
 {
     /**
      * Whether or not query logging is enabled.
@@ -52,12 +53,10 @@ class Connection extends Client
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
      * Returns a SchemaCollection stub until we can add more
      * abstract API's in Connection.
      *
-     * @return bool
+     * @return \Cake\ElasticSearch\Datasource\SchemaCollection
      */
     public function schemaCollection()
     {
@@ -65,9 +64,7 @@ class Connection extends Client
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function configName()
     {
@@ -75,9 +72,7 @@ class Connection extends Client
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @return bool
+     * {@inheritDoc}
      */
     public function enabled()
     {
@@ -85,37 +80,28 @@ class Connection extends Client
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function beginTransaction()
     {
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function disableForeignKeys()
     {
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function enableForeignKeys()
     {
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @param bool $enable Whether or not to log queries
-     * @return bool|void
+     * {@inheritDoc}
      */
     public function logQueries($enable = null)
     {
@@ -126,14 +112,22 @@ class Connection extends Client
     }
 
     /**
-     * Part of the implicit Connection interface.
-     *
-     * @param callable $callable An anonymous function to be called
-     * @return callable The result of the called function
+     * {@inheritDoc}
      */
-    public function transactional($callable)
+    public function transactional(callable $callable)
     {
         return $callable($this);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Elasticsearch does not deal with the concept of foreign key constraints
+     * This method just triggers the $callback argument.
+     */
+    public function disableConstraints(callable $callback)
+    {
+        return $callback($this);
     }
 
     /**

--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -14,7 +14,8 @@
  */
 namespace Cake\ElasticSearch\TestSuite;
 
-use Cake\ElasticSearch\Datasource\Connection;
+use Cake\Datasource\ConnectionInterface;
+use Cake\Datasource\FixtureInterface;
 use Elastica\Query\MatchAll;
 use Elastica\Type\Mapping as ElasticaMapping;
 
@@ -25,7 +26,7 @@ use Elastica\Type\Mapping as ElasticaMapping;
  *
  * Class extension is temporary as fixtures are missing an interface.
  */
-class TestFixture
+class TestFixture implements FixtureInterface
 {
 
     /**
@@ -70,11 +71,10 @@ class TestFixture
     /**
      * Create the mapping for the type.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
-     *  connection
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      * @return void
      */
-    public function create(Connection $db)
+    public function create(ConnectionInterface $db)
     {
         if (empty($this->schema)) {
             return;
@@ -95,11 +95,10 @@ class TestFixture
     /**
      * Insert fixture documents.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
-     *  connection
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      * @return void
      */
-    public function insert(Connection $db)
+    public function insert(ConnectionInterface $db)
     {
         if (empty($this->records)) {
             return;
@@ -123,11 +122,10 @@ class TestFixture
     /**
      * Drops a mapping and all its related data.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
-     *  connection
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      * @return void
      */
-    public function drop(Connection $db)
+    public function drop(ConnectionInterface $db)
     {
         $index = $db->getIndex();
         $type = $index->getType($this->table);
@@ -138,11 +136,10 @@ class TestFixture
     /**
      * Truncate the fixture type.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
-     *  connection
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      * @return void
      */
-    public function truncate(Connection $db)
+    public function truncate(ConnectionInterface $db)
     {
         $query = new MatchAll();
         $index = $db->getIndex();
@@ -152,14 +149,29 @@ class TestFixture
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function connection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sourceName()
+    {
+        return $this->table;
+    }
+
+    /**
      * No-op method needed because of the Fixture interface.
      * Elasticsearch does not deal with foreign key constraints.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
-     *  connection
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      * @return void
      */
-    public function createConstraints(Connection $db)
+    public function createConstraints(ConnectionInterface $db)
     {
     }
 
@@ -167,11 +179,11 @@ class TestFixture
      * No-op method needed because of the Fixture interface.
      * Elasticsearch does not deal with foreign key constraints.
      *
-     * @param \Cake\ElasticSearch\Datasource\Connection $db The Elasticsearch
+     * @param \Cake\Datasource\ConnectionInterface $db The Elasticsearch connection
      *  connection
      * @return void
      */
-    public function dropConstraints(Connection $db)
+    public function dropConstraints(ConnectionInterface $db)
     {
     }
 }


### PR DESCRIPTION
Now that interfaces were extracted for ``Connection`` and ``Fixtures`` objects, the ElasticSearch ``Connection`` and ``Fixtures`` objects should implements them.