### PR TITLE
Allow find() call chaining like DB ORM

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -247,10 +247,8 @@ class Query implements IteratorAggregate
     }
 
     /**
-     * Allow chaining custom finders on the same Query like the ORM
+     * {@inheritDoc}
      *
-     * @param  string $type
-     * @param  array  $options
      * @return \Cake\ElasticSearch\Query
      */
     public function find($type = 'all', $options = [])

--- a/src/Query.php
+++ b/src/Query.php
@@ -247,6 +247,18 @@ class Query implements IteratorAggregate
     }
 
     /**
+     * Allow chaining custom finders on the same Query like the ORM
+     *
+     * @param  string $type
+     * @param  array  $options
+     * @return \Cake\ElasticSearch\Query
+     */
+    public function find($type = 'all', $options = [])
+    {
+        return $this->_repository->callFinder($type, $this, $options);
+    }
+
+    /**
      * Sets the filter to use in a FilteredQuery object. Filters added using this method
      * will be stacked on a bool filter and applied to the filter part of a filtered query.
      *

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -39,6 +39,18 @@ class QueryTest extends TestCase
     }
 
     /**
+     * Test that chained finders will work
+     *
+     * @return void
+     */
+    public function testChainedFinders()
+    {
+        $type = new Type();
+        $query = new Query($type);
+        $query->find()->find();
+    }
+
+    /**
      * Tests that executing a query means executing a search against the associated
      * Type and decorates the internal ResultSet
      *


### PR DESCRIPTION
Will allow for code like this

````php
        $result = TypeRegistry::get('ElasticLocation')
            ->find('city')
            ->find('forRequest')
            ->find('within', compact('latitude', 'longitude'))
            ->first();
````