### PR TITLE
Elastic 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "source": "https://github.com/cakephp/elastic-search"
     },
     "require": {
-        "ruflin/elastica": "~2.2",
-        "cakephp/cakephp": "~3.1"
+        "ruflin/elastica": "~3.1",
+        "cakephp/cakephp": "~3.2"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-master",

--- a/src/Query.php
+++ b/src/Query.php
@@ -182,8 +182,8 @@ class Query implements IteratorAggregate
      * integers. This is summary of the return types for each clause.
      *
      * - fields: array, will return empty array when no fields are set
-     * - preFilter: The filter to use in a FilteredQuery object, returns null when not set
-     * - postFilter: The filter to use in the post_filter object, returns null when not set
+     * - preFilter: The query to use in a BoolQuery filter object, returns null when not set
+     * - postFilter: The query to use in the post_filter object, returns null when not set
      * - query: Raw query (Elastica\Query\AbstractQuery), return null when not set
      * - order: OrderByExpression, returns null when not set
      * - limit: integer, null when not set
@@ -255,14 +255,14 @@ class Query implements IteratorAggregate
     }
 
     /**
-     * Sets the filter to use in a FilteredQuery object. Filters added using this method
-     * will be stacked on a bool filter and applied to the filter part of a filtered query.
+     * Sets the filter to use in a BoolQuery filter object. Queries added using this method
+     * will be stacked on a bool query and applied to the filter part of a filtered query.
      *
      * There are several way in which you can use this method. The easiest one is by passing
      * a simple array of conditions:
      *
      * {{{
-     *   // Generates a {"term": {"name": "jose"}} json filter
+     *   // Generates a {"term": {"name": "jose"}} json query
      *   $query->where(['name' => 'jose']);
      * }}}
      *
@@ -274,10 +274,10 @@ class Query implements IteratorAggregate
      * }}}
      *
      * You can read about the available operators and how they translate to Elastic Search
-     * filters in the `Cake\ElasticSearch\QueryBuilder::parse()` method documentation.
+     * queries in the `Cake\ElasticSearch\QueryBuilder::parse()` method documentation.
      *
      * Additionally, it is possible to use a closure as first argument. The closure will receive
-     * a QueryBuilder instance, that you can use for creating arbitrary filter combinations:
+     * a QueryBuilder instance, that you can use for creating arbitrary queries combinations:
      *
      * {{{
      *   $query->where(function ($builder) {
@@ -285,14 +285,14 @@ class Query implements IteratorAggregate
      *   });
      * }}}
      *
-     * Finally, you can pass any already built filters as first argument:
+     * Finally, you can pass any already built queries as first argument:
      *
      * {{{
      *   $query->where(new \Elastica\Filter\Term('name.first', 'jose'));
      * }}{
      *
      * @param array|callable|\Elastica\Filter\AbstractFilter $conditions The list of conditions.
-     * @param bool $overwrite Whether or not to replace previous filters.
+     * @param bool $overwrite Whether or not to replace previous queries.
      * @return $this
      * @see Cake\ElasticSearch\FilterBuilder
      */
@@ -302,8 +302,8 @@ class Query implements IteratorAggregate
     }
 
     /**
-     * Sets the filter to use in the post_filter object. Filters added using this method
-     * will be stacked on a bool filter.
+     * Sets the query to use in the post_filter object. Filters added using this method
+     * will be stacked on a BoolQuery.
      *
      * This method can be used in the same way the `where()` method is used. Please refer to
      * its documentation for more details.

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -2,22 +2,44 @@
 
 namespace Cake\ElasticSearch;
 
-use Elastica\Filter;
-use Elastica\Filter\AbstractFilter;
 use Elastica\Query\AbstractQuery;
+use Elastica\Query\BoolQuery;
+use Elastica\Query\Exists;
+use Elastica\Query\GeoBoundingBox;
+use Elastica\Query\GeoDistance;
+use Elastica\Query\GeoDistanceRange;
+use Elastica\Query\GeohashCell;
+use Elastica\Query\GeoPolygon;
+use Elastica\Query\GeoShapePreIndexed;
+use Elastica\Query\GeoShapeProvided;
+use Elastica\Query\HasChild;
+use Elastica\Query\HasParent;
+use Elastica\Query\Ids;
+use Elastica\Query\Indices;
+use Elastica\Query\Limit;
+use Elastica\Query\MatchAll;
+use Elastica\Query\Missing;
+use Elastica\Query\Nested;
+use Elastica\Query\Prefix;
+use Elastica\Query\Range;
+use Elastica\Query\Regexp;
+use Elastica\Query\Script;
+use Elastica\Query\Term;
+use Elastica\Query\Terms;
+use Elastica\Query\Type;
 
-class FilterBuilder
+class QueryBuilder
 {
 
     /**
-     * Returns a Range filter object setup to filter documents having the field between
+     * Returns a Range query object setup to filter documents having the field between
      * a `from` and a `to` value
      *
      * @param string $field The field to filter by.
      * @param mixed $from The lower bound value.
      * @param mixed $to The upper bound value.
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      */
     public function between($field, $from, $to)
     {
@@ -28,15 +50,15 @@ class FilterBuilder
     }
 
     /**
-     * Returns a bool filter that can be chained with the `addMust()`, `addShould()`
-     * and `addMustNot()` methods.
+     * Returns a bool query that can be chained with the `addMust()`, `addShould()`,
+     * `addFilter` and `addMustNot()` methods.
      *
-     * @return \Elastica\Filter\BoolFilter
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html
+     * @return \Elastica\Query\BoolQuery
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
      */
     public function bool()
     {
-        return new Filter\BoolFilter();
+        return new BoolQuery();
     }
 
     /**
@@ -45,106 +67,106 @@ class FilterBuilder
      *
      * @param string $field The field to check for existance.
      * @return \Elastica\Filter\Exists
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
      */
     public function exists($field)
     {
-        return new Filter\Exists($field);
+        return new Exists($field);
     }
 
     /**
-     * Returns a GeoBoundingBox filter object setup to filter documents having a property
+     * Returns a GeoBoundingBox query object setup to query documents having a property
      * bound by two coordinates.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoBoundingBox('location', [40.73, -74.1], [40.01, -71.12]);
+     *    $query = $builder->geoBoundingBox('location', [40.73, -74.1], [40.01, -71.12]);
      *
-     *    $filter = $builder->geoBoundingBox(
+     *    $query = $builder->geoBoundingBox(
      *        'location',
      *        ['lat => 40.73, 'lon' => -74.1],
      *        ['lat => 40.01, 'lon' => -71.12]
      *    );
      *
-     *    $filter = $builder->geoBoundingBox('location', 'dr5r9ydj2y73', 'drj7teegpus6');
+     *    $query = $builder->geoBoundingBox('location', 'dr5r9ydj2y73', 'drj7teegpus6');
      * }}}
      *
      * @param string $field The field to compare.
      * @param array|string $topLeft The top left coordinate.
      * @param array|string $bottomRight The bottom right coordinate.
-     * @return \Elastica\Filter\GeoBoundingBox
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-filter.html
+     * @return \Elastica\Query\GeoBoundingBox
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
      */
     public function geoBoundingBox($field, $topLeft, $bottomRight)
     {
-        return new Filter\GeoBoundingBox($field, [$topLeft, $bottomRight]);
+        return new GeoBoundingBox($field, [$topLeft, $bottomRight]);
     }
 
     /**
-     * Returns an GeoDistance filter object setup to filter documents having a property
+     * Returns an GeoDistance query object setup to query documents having a property
      * in the radius distance of a coordinate.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoDistance('location', [40.73, -74.1], '10km');
+     *    $query = $builder->geoDistance('location', [40.73, -74.1], '10km');
      *
-     *    $filter = $builder->geoBoundingBox('location', 'dr5r9ydj2y73', '5km');
+     *    $query = $builder->geoBoundingBox('location', 'dr5r9ydj2y73', '5km');
      * }}}
      *
      * @param string $field The field to compare.
      * @param array|string $location The coordinate from which to compare.
      * @param string $distance The distance radius.
-     * @return \Elastica\Filter\GeoDistance
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-range-filter.html
+     * @return \Elastica\Query\GeoDistance
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
      */
     public function geoDistance($field, $location, $distance)
     {
-        return new Filter\GeoDistance($field, $location, $distance);
+        return new GeoDistance($field, $location, $distance);
     }
 
     /**
-     * Returns an GeoDistanceRange filter object setup to filter documents having a property
+     * Returns an GeoDistanceRange query object setup to query documents having a property
      * in between two distance radius from a location coordinate.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoDistanceRange('location', [40.73, -74.1], '10km', '20km');
+     *    $query = $builder->geoDistanceRange('location', [40.73, -74.1], '10km', '20km');
      *
-     *    $filter = $builder->geoDistanceRange('location', 'dr5r9ydj2y73', '5km', '10km');
+     *    $query = $builder->geoDistanceRange('location', 'dr5r9ydj2y73', '5km', '10km');
      * }}}
      *
      * @param string $field The field to compare.
      * @param array|string $location The coordinate from which to compare.
      * @param string $from The initial distance radius.
      * @param string $to The ending distance radius.
-     * @return \Elastica\Filter\GeoDistanceRange
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-filter.html
+     * @return \Elastica\Query\GeoDistanceRange
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-range-query.html
      */
     public function geoDistanceRange($field, $location, $from, $to)
     {
-        return new Filter\GeoDistanceRange($field, $location, [
+        return new GeoDistanceRange($field, $location, [
             'gte' => $from,
             'lte' => $to
         ]);
     }
 
     /**
-     * Returns an GeoPolygon filter object setup to filter documents having a property
+     * Returns an GeoPolygon query object setup to query documents having a property
      * enclosed in the polygon induced by the passed geo points.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoPolygon('location', [
+     *    $query= $builder->geoPolygon('location', [
      *        ['lat' => 40, 'lon' => -70],
      *        ['lat' => 30, 'lon' => -80],
      *        ['lat' => 20, 'lon' => -90],
      *    ]);
      *
-     *    $filter = $builder->geoPolygon('location', [
+     *    $query = $builder->geoPolygon('location', [
      *        'drn5x1g8cu2y',
      *        ['lat' => 30, 'lon' => -80],
      *        '20, -90',
@@ -153,51 +175,51 @@ class FilterBuilder
      *
      * @param string $field The field to compare.
      * @param array $geoPoints List of geo points that form the polygon
-     * @return \Elastica\Filter\GeoPolygon
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html
+     * @return \Elastica\Query\GeoPolygon
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-query.html
      */
     public function geoPolygon($field, array $geoPoints)
     {
-        return new Filter\GeoPolygon($field, $geoPoints);
+        return new GeoPolygon($field, $geoPoints);
     }
 
     /**
-     * Returns an GeoShapeProvided filter object setup to filter documents having a property
+     * Returns an GeoShapeProvided query object setup to query documents having a property
      * enclosed in the specified geometrical shape type.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoShape('location', [[13.0, 53.0], [14.0, 52.0]], 'envelope');
+     *    $query = $builder->geoShape('location', [[13.0, 53.0], [14.0, 52.0]], 'envelope');
      *
-     *    $filter = $builder->geoShape('location', [
+     *    $query = $builder->geoShape('location', [
      *        [[-77.03653, 38.897676], [-77.009051, 38.889939]],
      *        'linestring'
      *    ]);
      * }}}
      *
      * You can read about the supported shapes and how they are created here:
-     * http://www.elastic.co/guide/en/elasticsearch/reference/1.x/mapping-geo-shape-type.html
+     * https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html
      *
      * @param string $field The field to compare.
      * @param array $geoPoints List of geo points that form the shape.
      * @param string $type The shape type to use (envelope, linestring, polygon, multipolygon...)
-     * @return \Elastica\Filter\GeoShapeProvided
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+     * @return \Elastica\Query\GeoShapeProvided
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
      */
     public function geoShape($field, array $geoPoints, $type = 'envelope')
     {
-        return new Filter\GeoShapeProvided($field, $geoPoints, $type);
+        return new GeoShapeProvided($field, $geoPoints, $type);
     }
 
     /**
-     * Returns an GeoShapePreIndex filter object setup to filter documents having a property
+     * Returns an GeoShapePreIndex query object setup to query documents having a property
      * enclosed in the specified geometrical shape type.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoShapeIndex('location', 'DEU', 'countries', 'shapes', 'location');
+     *    $query = $builder->geoShapeIndex('location', 'DEU', 'countries', 'shapes', 'location');
      * }}}
      *
      * @param string $field The field to compare.
@@ -205,44 +227,44 @@ class FilterBuilder
      * @param string $type Index type where the pre-indexed shape is.
      * @param string $index Name of the index where the pre-indexed shape is.
      * @param string $path The field specified as path containing the pre-indexed shape.
-     * @return \Elastica\Filter\GeoShapePreIndexed
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+     * @return \Elastica\Query\GeoShapePreIndexed
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
      */
     public function geoShapeIndex($field, $id, $type, $index = 'shapes', $path = 'shape')
     {
-        return new Filter\GeoShapePreIndexed($field, $id, $type, $index, $path);
+        return new GeoShapePreIndexed($field, $id, $type, $index, $path);
     }
 
     /**
-     * Returns an GeohashCell filter object setup to filter documents having a property
+     * Returns an GeohashCell query object setup to query documents having a property
      * enclosed inside the specified geohash in teh give precision.
      *
      * ### Example:
      *
      * {{{
-     *    $filter = $builder->geoHashCell('location', [40, -70], 3);
+     *    $query = $builder->geoHashCell('location', [40, -70], 3);
      * }}}
      *
      * @param string $field The field to compare.
      * @param string|array $location Location as coordinates array or geohash string.
      * @param int|string $precision Length of geohash prefix or distance (3, or "50m")
-     * @param bool $neighbors If true, filters cells next to the given cell.
-     * @return \Elastica\Filter\GeohashCell
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-filter.html
+     * @param bool $neighbors If true, query cells next to the given cell.
+     * @return \Elastica\Query\GeohashCell
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-query.html
      */
     public function geoHashCell($field, $location, $precision = -1, $neighbors = false)
     {
-        return new Filter\GeohashCell($field, $location, $precision, $neighbors);
+        return new GeohashCell($field, $location, $precision, $neighbors);
     }
 
     /**
-     * Returns a Range filter object setup to filter documents having the field
+     * Returns a Range query object setup to query documents having the field
      * greater than the provided value.
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param mixed $value The value to compare with.
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      */
     public function gt($field, $value)
     {
@@ -250,13 +272,13 @@ class FilterBuilder
     }
 
     /**
-     * Returns a Range filter object setup to filter documents having the field
+     * Returns a Range query object setup to filter documents having the field
      * greater than or equal the provided value.
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param mixed $value The value to compare with.
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      */
     public function gte($field, $value)
     {
@@ -267,46 +289,46 @@ class FilterBuilder
      * Accepts a query and the child type to run against, and results in parent
      * documents that have child docs matching the query.
      *
-     * @param string|\Elastica\Query|\Elastica\Filter\AbstractFilter $query The filtering conditions.
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query The query.
      * @param string $type The child type to query against.
-     * @return \Elastica\Filter\HasChild
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-filter.html
+     * @return \Elastica\Query\HasChild
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
      */
     public function hasChild($query, $type)
     {
-        return new Filter\HasChild($query, $type);
+        return new HasChild($query, $type);
     }
 
     /**
-     * Filters by child documents having parent documents matching the query
+     * Query by child documents having parent documents matching the query
      *
-     * @param string|\Elastica\Query|\Elastica\Filter\AbstractFilter $query The filtering conditions.
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query The query.
      * @param string $type The parent type to query against.
      * @return \Elastica\Filter\HasParent
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-filter.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
      */
     public function hasParent($query, $type)
     {
-        return new Filter\HasParent($query, $type);
+        return new HasParent($query, $type);
     }
 
     /**
-     * Filters documents that only have the provided ids.
+     * Query documents that only have the provided ids.
      *
-     * @param array $ids The list of ids to filter by.
+     * @param array $ids The list of ids to query by.
      * @param string|array $type A single or multiple types in which the ids should be searched.
-     * @return \Elastica\Filter\Ids
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-filter.html
+     * @return \Elastica\Query\Ids
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
      */
     public function ids(array $ids = [], $type = null)
     {
-        return new Filter\Ids($type, $ids);
+        return new Ids($type, $ids);
     }
 
     /**
-     * The indices filter can be used when executed across multiple indices, allowing you to have a filter
+     * The indices query can be used when executed across multiple indices, allowing you to have a query
      * that is only applied when executed on an index matching a specific list of indices, and another
-     * filter that executes when it is executed on an index that does not match the listed indices.
+     * query that executes when it is executed on an index that does not match the listed indices.
      *
      * ### Example:
      *
@@ -318,50 +340,50 @@ class FilterBuilder
      *    );
      * }}}
      *
-     * @param array $indices The indices where to apply the filter.
-     * @param \Elastica\Filter\AbstractFilter $match Filter which will be applied to docs
+     * @param array $indices The indices where to apply the query.
+     * @param \Elastica\Query\AbstractQuery $query Query which will be applied to docs
      * in the specified indices.
-     * @param \Elastica\Filter\AbstractFilter $noMatch Filter to apply to documents not present
+     * @param \Elastica\Query\AbstractQuery $noMatch Query to apply to documents not present
      * in the specified indices.
      * @return \Elastica\Filter\Indices
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-filter.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html
      */
-    public function indices(array $indices, AbstractFilter $match, AbstractFilter $noMatch)
+    public function indices(array $indices, AbstractQuery $query, AbstractQuery $noMatch)
     {
-        return (new Filter\Indices($match, $indices))->setNoMatchFilter($noMatch);
+        return (new Indices($query, $indices))->setNoMatchQuery($noMatch);
     }
 
     /**
      * Limits the number of documents (per shard) to execute on.
      *
-     * @param int $limit The maximum number of documents to filter.
-     * @return \Elastica\Filter\Limit
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-filter.html
+     * @param int $limit The maximum number of documents to query.
+     * @return \Elastica\Query\Limit
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-query.html
      */
     public function limit($limit)
     {
-        return new Filter\Limit((int)$limit);
+        return new Limit((int)$limit);
     }
 
     /**
-     * A filter that returns all documents.
+     * A query that returns all documents.
      *
-     * @return \Elastica\Filter\MatchAll
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-filter.html
+     * @return \Elastica\Query\MatchAll
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
      */
     public function matchAll()
     {
-        return new Filter\MatchAll();
+        return new MatchAll();
     }
 
     /**
-     * Returns a Range filter object setup to filter documents having the field
+     * Returns a Range query object setup to filter documents having the field
      * smaller than the provided value.
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param mixed $value The value to compare with.
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      */
     public function lt($field, $value)
     {
@@ -369,13 +391,13 @@ class FilterBuilder
     }
 
     /**
-     * Returns a Range filter object setup to filter documents having the field
+     * Returns a Range query object setup to query documents having the field
      * smaller or equals than the provided value.
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param mixed $value The value to compare with.
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      */
     public function lte($field, $value)
     {
@@ -383,20 +405,20 @@ class FilterBuilder
     }
 
     /**
-     * Returns a Missing filter object setup to filter documents not having a property present or
+     * Returns a Missing query object setup to query documents not having a property present or
      * not null.
      *
      * @param string $field The field to check for existance.
-     * @return \Elastica\Filter\Missing
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+     * @return \Elastica\Query\Missing
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-missing-query.html
      */
     public function missing($field = '')
     {
-        return new Filter\Missing($field);
+        return new Missing($field);
     }
 
     /**
-     * Returns a Nested filter object setup to filter sub documents by a path.
+     * Returns a Nested query object setup to query sub documents by a path.
      *
      * ### Example:
      *
@@ -404,78 +426,55 @@ class FilterBuilder
      *    $builder->nested('comments', $builder->term('author', 'mark'));
      * }}}
      *
-     * Or using a query as filter:
-     *
-     * {{{
-     *    $builder->nested('comments', new \Elastica\Query\SimpleQueryString('awesome'));
-     * }}}
      *
      * @param string $path A dot separated string denoting the path to the property to filter.
-     * @param \Elastica\Query\AbstractQuery|\Elastica\Filter\AbstractFilter $filter The filtering conditions.
-     * @return \Elastica\Filter\Nested
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html
+     * @param \Elastica\Query\AbstractQuery $query The query conditions.
+     * @return \Elastica\Query\Nested
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
      */
-    public function nested($path, $filter)
+    public function nested($path, $query)
     {
-        $nested = new Filter\Nested();
+        $nested = new Nested();
         $nested->setPath($path);
 
-        if ($filter instanceof AbstractFilter) {
-            $nested->setFilter($filter);
-        }
+        $nested->setQuery($query);
 
-        if ($filter instanceof AbstractQuery) {
-            $nested->setQuery($filter);
-        }
         return $nested;
     }
 
     /**
-     * Returns a BoolNot filter that is typically ussed to negate another filter expression
+     * Returns a BoolQuery query with must_not field that is typically ussed to negate another query expression
      *
-     * @param \Elastica\Filter\AbstractFilter $filter The filter to negate
-     * @return \Elastica\Filter\BoolNot
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-not-filter.html
+     * @param \Elastica\Query\AbstractQuery|array $query The query to negate
+     * @return \Elastica\Query\BoolQuery
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
      */
-    public function not($filter)
+    public function not($query)
     {
-        return new Filter\BoolNot($filter);
+        $boolQuery = new BoolQuery();
+        $boolQuery->addMustNot($query);
+        return $boolQuery;
     }
 
     /**
-     * Returns a Prefix filter to filter documents that have fields containing terms with
+     * Returns a Prefix query to filter documents that have fields containing terms with
      * a specified prefix
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param string $prefix The prefix to check for.
-     * @return \Elastica\Filter\Prefix
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-filter.html
+     * @param float $boost The optional boost
+     * @return Prefix
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
      */
-    public function prefix($field, $prefix)
+    public function prefix($field, $prefix, $boost = 1.0)
     {
-        return new Filter\Prefix($field, $prefix);
+        $prefixQuery = new Prefix;
+        $prefixQuery->setPrefix($field, $prefix, $boost);
+        return $prefixQuery;
     }
 
     /**
-     * Returns a Query filter that Wraps any query to be used as a filter.
-     *
-     * ### Example:
-     *
-     * {{{
-     *  $builder->query(new \Elastica\Query\SimpleQueryString('awesome OR great'));
-     * }}}
-     *
-     * @param array|\Elastica\Query\AbstractQuery $query The Query to wrap as a filter
-     * @return \Elastica\Filter\Query
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-filter.html
-     */
-    public function query($query)
-    {
-        return new Filter\Query($query);
-    }
-
-    /**
-     * Returns a Range filter object setup to filter documents having the field
+     * Returns a Range query object setup to query documents having the field
      * greater than the provided values.
      *
      * The $args array accepts the following keys:
@@ -485,18 +484,18 @@ class FilterBuilder
      * - lte: less than or equal
      * - lt: less than
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param array $args An array describing the search range
-     * @return \Elastica\Filter\Range
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+     * @return \Elastica\Query\Range
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-range-query.html
      */
     public function range($field, array $args)
     {
-        return new Filter\Range($field, $args);
+        return new Range($field, $args);
     }
 
     /**
-     * Returns a Regexp filter to filter documents based on a regular expression.
+     * Returns a Regexp query to query documents based on a regular expression.
      *
      * ### Example:
      *
@@ -504,19 +503,19 @@ class FilterBuilder
      *  $builder->regexp('name.first', 'ma.*');
      * }}}
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param string $regexp The regular expression.
      * @param array $options Regultar expression flags or options.
-     * @return \Elastica\Filter\Regexp
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
+     * @return \Elastica\Query\Regexp
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-regexp-query.html
      */
     public function regexp($field, $regexp, array $options = [])
     {
-        return new Filter\Regexp($field, $regexp, $options);
+        return new Regexp($field, $regexp, $options);
     }
 
     /**
-     * Returns a Script filter object that allows to filter based on the return value of a script.
+     * Returns a Script query object that allows to query based on the return value of a script.
      *
      * ### Example:
      *
@@ -524,17 +523,17 @@ class FilterBuilder
      *  $builder->script("doc['price'].value > 1");
      * }}}
      *
-     * @param string $script The script.
-     * @return \Elastica\Filter\Regexp
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
+     * @param array|string|\Elastica\Script\AbstractScript $script The script.
+     * @return \Elastica\Query\Script
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-script-query.html
      */
     public function script($script)
     {
-        return new Filter\Script($script);
+        return new Script($script);
     }
 
     /**
-     * Returns a Term filter object that filters documents that have fields containing a term.
+     * Returns a Term query object that query documents that have fields containing a term.
      *
      * ### Example:
      *
@@ -542,18 +541,18 @@ class FilterBuilder
      *  $builder->term('user.name', 'jose');
      * }}}
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param string $value The term to find in field.
-     * @return \Elastica\Filter\Term
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-filter.html
+     * @return \Elastica\Query\Term
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-term-query.html
      */
     public function term($field, $value)
     {
-        return new Filter\Term([$field => $value]);
+        return new Term([$field => $value]);
     }
 
     /**
-     * Returns a Terms filter object that filters documents that have fields containing some terms.
+     * Returns a Terms query object that query documents that have fields containing some terms.
      *
      * ### Example:
      *
@@ -561,18 +560,18 @@ class FilterBuilder
      *  $builder->terms('user.name', ['jose', 'mark']);
      * }}}
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param array $values The list of terms to find in field.
-     * @return \Elastica\Filter\Terms
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
+     * @return \Elastica\Query\Terms
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-terms-query.html
      */
     public function terms($field, $values)
     {
-        return new Filter\Terms($field, $values);
+        return new Terms($field, $values);
     }
 
     /**
-     * Returns a Type filter object that filters documents matching the provided document/mapping type.
+     * Returns a Type query object that query documents matching the provided document/mapping type.
      *
      * ### Example:
      *
@@ -581,16 +580,16 @@ class FilterBuilder
      * }}}
      *
      * @param string $type The type name
-     * @return \Elastica\Filter\Type
-     * @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html
+     * @return \Elastica\Query\Type
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-type-query.html
      */
     public function type($type)
     {
-        return new Filter\Type($type);
+        return new Type($type);
     }
 
     /**
-     * Combines all the passed arguments in a single boolean filter
+     * Combines all the passed arguments in a single bool query
      * using the "must" clause.
      *
      * ### Example:
@@ -602,29 +601,22 @@ class FilterBuilder
      *  );
      * }}}
      *
-     * @return \Elastica\Filter\BoolFilter
+     * @return \Elastica\Query\BoolQuery
      */
     // @codingStandardsIgnoreStart
     public function and_()
     {
         // @codingStandardsIgnoreEnd
-        $filters = func_get_args();
+        $queries = func_get_args();
         $bool = $this->bool();
 
-        foreach ($filters as $k => $filter) {
-            if ($filter instanceof Filter\BoolFilter) {
-                $bool = $filter;
-                unset($filters[$k]);
-                break;
-            }
-        }
-
-        foreach ($filters as $filter) {
-            $bool->addMust($filter);
+        foreach ($queries as $query) {
+            $bool->addMust($query);
         }
 
         return $bool;
     }
+
 
     /**
      * Combines all the passed arguments in a single BoolOr filter.
@@ -644,14 +636,14 @@ class FilterBuilder
     public function or_()
     {
         // @codingStandardsIgnoreEnd
-        $filters = func_get_args();
-        $or = new Filter\BoolOr();
+        $queries = func_get_args();
+        $bool = $this->bool();
 
-        foreach ($filters as $filter) {
-            $or->addFilter($filter);
+        foreach ($queries as $query) {
+            $bool->addShould($query);
         }
 
-        return $or;
+        return $bool;
     }
 
     /**
@@ -670,18 +662,18 @@ class FilterBuilder
     }
 
     /**
-     * Converts an array into a single array of filter objects
+     * Converts an array into a single array of query objects
      *
      * ### Parsing a single array:
      *
      *   {{{
-     *       $filter = $builder->parse([
+     *       $query = $builder->parse([
      *           'name' => 'mark',
      *           'age <=' => 35
      *       ]);
      *
      *       // Equivalent to:
-     *       $filter = [
+     *       $query = [
      *           $builder->term('name', 'mark'),
      *           $builder->lte('age', 35)
      *       ];
@@ -690,7 +682,7 @@ class FilterBuilder
      * ### Creating "or" conditions:
      *
      * {{{
-     *  $filter = $builder->parse([
+     *  $query = $builder->parse([
      *      'or' => [
      *          'name' => 'mark',
      *          'age <=' => 35
@@ -698,7 +690,7 @@ class FilterBuilder
      *  ]);
      *
      *  // Equivalent to:
-     *  $filter = [$builder->or(
+     *  $query = [$builder->or(
      *      $builder->term('name', 'mark'),
      *      $builder->lte('age', 35)
      *  )];
@@ -707,7 +699,7 @@ class FilterBuilder
      * ### Negating conditions:
      *
      * {{{
-     *  $filter = $builder->parse([
+     *  $query = $builder->parse([
      *      'not' => [
      *          'name' => 'mark',
      *          'age <=' => 35
@@ -715,7 +707,7 @@ class FilterBuilder
      *  ]);
      *
      *  // Equivalent to:
-     *  $filter = [$builder->not(
+     *  $query = [$builder->not(
      *      $builder->and(
      *          $builder->term('name', 'mark'),
      *          $builder->lte('age', 35)
@@ -725,13 +717,13 @@ class FilterBuilder
      *
      * ### Checking for field existance
      * {{{
-     *       $filter = $builder->parse([
+     *       $query = $builder->parse([
      *           'name is' => null,
      *           'age is not' => null
      *       ]);
      *
      *       // Equivalent to:
-     *       $filter = [
+     *       $query = [
      *           $builder->missing('name'),
      *           $builder->exists('age')
      *       ];
@@ -740,24 +732,24 @@ class FilterBuilder
      * ### Checking if a value is in a list of terms
      *
      * {{{
-     *       $filter = $builder->parse([
+     *       $query = $builder->parse([
      *           'name in' => ['jose', 'mark']
      *       ]);
      *
      *       // Equivalent to:
-     *       $filter = [$builder->terms('name', ['jose', 'mark'])]
+     *       $query = [$builder->terms('name', ['jose', 'mark'])]
      * }}}
      *
      * The list of supported operators is:
      *
      * `<`, `>`, `<=`, `>=`, `in`, `not in`, `is`, `is not`, `!=`
      *
-     * @param array|\Elastica\Filter\AbstractFilter $conditions The list of conditions to parse.
+     * @param array|\Elastica\Query\AbstractQuery $conditions The list of conditions to parse.
      * @return array
      */
     public function parse($conditions)
     {
-        if ($conditions instanceof AbstractFilter) {
+        if ($conditions instanceof AbstractQuery) {
             return $conditions;
         }
 
@@ -790,7 +782,7 @@ class FilterBuilder
                 continue;
             }
 
-            if ($c instanceof AbstractFilter) {
+            if ($c instanceof AbstractQuery) {
                 $result[] = $c;
                 continue;
             }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -9,10 +9,10 @@ class QueryBuilder
 {
 
     /**
-     * Returns a Range query object setup to filter documents having the field between
+     * Returns a Range query object setup to query documents having the field between
      * a `from` and a `to` value
      *
-     * @param string $field The field to filter by.
+     * @param string $field The field to query by.
      * @param mixed $from The lower bound value.
      * @param mixed $to The upper bound value.
      * @return \Elastica\Query\Range
@@ -39,12 +39,12 @@ class QueryBuilder
     }
 
     /**
-     * Returns an Exists filter object setup to filter documents having a property present
+     * Returns an Exists query object setup to query documents having a property present
      * or not set to null.
      *
      * @param string $field The field to check for existance.
      * @return \Elastica\Filter\Exists
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.2/query-dsl-exists-query.html
      */
     public function exists($field)
     {
@@ -249,7 +249,7 @@ class QueryBuilder
     }
 
     /**
-     * Returns a Range query object setup to filter documents having the field
+     * Returns a Range query object setup to query documents having the field
      * greater than or equal the provided value.
      *
      * @param string $field The field to query by.
@@ -354,7 +354,7 @@ class QueryBuilder
     }
 
     /**
-     * Returns a Range query object setup to filter documents having the field
+     * Returns a Range query object setup to query documents having the field
      * smaller than the provided value.
      *
      * @param string $field The field to query by.
@@ -404,7 +404,7 @@ class QueryBuilder
      * }}}
      *
      *
-     * @param string $path A dot separated string denoting the path to the property to filter.
+     * @param string $path A dot separated string denoting the path to the property to query.
      * @param \Elastica\Query\AbstractQuery $query The query conditions.
      * @return \Elastica\Query\Nested
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
@@ -434,13 +434,13 @@ class QueryBuilder
     }
 
     /**
-     * Returns a Prefix query to filter documents that have fields containing terms with
+     * Returns a Prefix query to query documents that have fields containing terms with
      * a specified prefix
      *
      * @param string $field The field to query by.
      * @param string $prefix The prefix to check for.
      * @param float $boost The optional boost
-     * @return Query\Prefix
+     * @return Elastica\Query\Prefix
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
      */
     public function prefix($field, $prefix, $boost = 1.0)
@@ -596,7 +596,7 @@ class QueryBuilder
 
 
     /**
-     * Combines all the passed arguments in a single BoolOr filter.
+     * Combines all the passed arguments in a single BoolQuery query using should clause.
      *
      * ### Example:
      *
@@ -607,7 +607,7 @@ class QueryBuilder
      *  );
      * }}}
      *
-     * @return \Elastica\Filter\BoolOr
+     * @return \Elastica\Query\BoolQuery
      */
     // @codingStandardsIgnoreStart
     public function or_()
@@ -635,7 +635,7 @@ class QueryBuilder
         if (in_array($method, ['and', 'or'])) {
             return call_user_func_array([$this, $method . '_'], $args);
         }
-        throw new \BadMethodCallException('Cannot build filter ' . $method);
+        throw new \BadMethodCallException('Cannot build query ' . $method);
     }
 
     /**
@@ -765,7 +765,7 @@ class QueryBuilder
             }
 
             if (!$numericKey) {
-                $result[] = $this->_parseFilter($k, $c);
+                $result[] = $this->_parseQuery($k, $c);
             }
         }
 
@@ -776,10 +776,10 @@ class QueryBuilder
      * Parses a field name containing an operator into a Filter object.
      *
      * @param string $field The filed name containing the operator
-     * @param mixed $value The value to pass to the filter
+     * @param mixed $value The value to pass to the query
      * @return \Elastica\Filter\AbstractFilter
      */
-    protected function _parseFilter($field, $value)
+    protected function _parseQuery($field, $value)
     {
         $operator = '=';
         $parts = explode(' ', trim($field), 2);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -2,31 +2,8 @@
 
 namespace Cake\ElasticSearch;
 
+use Elastica;
 use Elastica\Query\AbstractQuery;
-use Elastica\Query\BoolQuery;
-use Elastica\Query\Exists;
-use Elastica\Query\GeoBoundingBox;
-use Elastica\Query\GeoDistance;
-use Elastica\Query\GeoDistanceRange;
-use Elastica\Query\GeohashCell;
-use Elastica\Query\GeoPolygon;
-use Elastica\Query\GeoShapePreIndexed;
-use Elastica\Query\GeoShapeProvided;
-use Elastica\Query\HasChild;
-use Elastica\Query\HasParent;
-use Elastica\Query\Ids;
-use Elastica\Query\Indices;
-use Elastica\Query\Limit;
-use Elastica\Query\MatchAll;
-use Elastica\Query\Missing;
-use Elastica\Query\Nested;
-use Elastica\Query\Prefix;
-use Elastica\Query\Range;
-use Elastica\Query\Regexp;
-use Elastica\Query\Script;
-use Elastica\Query\Term;
-use Elastica\Query\Terms;
-use Elastica\Query\Type;
 
 class QueryBuilder
 {
@@ -58,7 +35,7 @@ class QueryBuilder
      */
     public function bool()
     {
-        return new BoolQuery();
+        return new Elastica\Query\BoolQuery();
     }
 
     /**
@@ -71,7 +48,7 @@ class QueryBuilder
      */
     public function exists($field)
     {
-        return new Exists($field);
+        return new Elastica\Query\Exists($field);
     }
 
     /**
@@ -100,7 +77,7 @@ class QueryBuilder
      */
     public function geoBoundingBox($field, $topLeft, $bottomRight)
     {
-        return new GeoBoundingBox($field, [$topLeft, $bottomRight]);
+        return new Elastica\Query\GeoBoundingBox($field, [$topLeft, $bottomRight]);
     }
 
     /**
@@ -123,7 +100,7 @@ class QueryBuilder
      */
     public function geoDistance($field, $location, $distance)
     {
-        return new GeoDistance($field, $location, $distance);
+        return new Elastica\Query\GeoDistance($field, $location, $distance);
     }
 
     /**
@@ -147,7 +124,7 @@ class QueryBuilder
      */
     public function geoDistanceRange($field, $location, $from, $to)
     {
-        return new GeoDistanceRange($field, $location, [
+        return new Elastica\Query\GeoDistanceRange($field, $location, [
             'gte' => $from,
             'lte' => $to
         ]);
@@ -180,7 +157,7 @@ class QueryBuilder
      */
     public function geoPolygon($field, array $geoPoints)
     {
-        return new GeoPolygon($field, $geoPoints);
+        return new Elastica\Query\GeoPolygon($field, $geoPoints);
     }
 
     /**
@@ -209,7 +186,7 @@ class QueryBuilder
      */
     public function geoShape($field, array $geoPoints, $type = 'envelope')
     {
-        return new GeoShapeProvided($field, $geoPoints, $type);
+        return new Elastica\Query\GeoShapeProvided($field, $geoPoints, $type);
     }
 
     /**
@@ -232,7 +209,7 @@ class QueryBuilder
      */
     public function geoShapeIndex($field, $id, $type, $index = 'shapes', $path = 'shape')
     {
-        return new GeoShapePreIndexed($field, $id, $type, $index, $path);
+        return new Elastica\Query\GeoShapePreIndexed($field, $id, $type, $index, $path);
     }
 
     /**
@@ -254,7 +231,7 @@ class QueryBuilder
      */
     public function geoHashCell($field, $location, $precision = -1, $neighbors = false)
     {
-        return new GeohashCell($field, $location, $precision, $neighbors);
+        return new Elastica\Query\GeohashCell($field, $location, $precision, $neighbors);
     }
 
     /**
@@ -296,7 +273,7 @@ class QueryBuilder
      */
     public function hasChild($query, $type)
     {
-        return new HasChild($query, $type);
+        return new Elastica\Query\HasChild($query, $type);
     }
 
     /**
@@ -309,7 +286,7 @@ class QueryBuilder
      */
     public function hasParent($query, $type)
     {
-        return new HasParent($query, $type);
+        return new Elastica\Query\HasParent($query, $type);
     }
 
     /**
@@ -322,7 +299,7 @@ class QueryBuilder
      */
     public function ids(array $ids = [], $type = null)
     {
-        return new Ids($type, $ids);
+        return new Elastica\Query\Ids($type, $ids);
     }
 
     /**
@@ -350,7 +327,7 @@ class QueryBuilder
      */
     public function indices(array $indices, AbstractQuery $query, AbstractQuery $noMatch)
     {
-        return (new Indices($query, $indices))->setNoMatchQuery($noMatch);
+        return (new Elastica\Query\Indices($query, $indices))->setNoMatchQuery($noMatch);
     }
 
     /**
@@ -362,7 +339,7 @@ class QueryBuilder
      */
     public function limit($limit)
     {
-        return new Limit((int)$limit);
+        return new Elastica\Query\Limit((int)$limit);
     }
 
     /**
@@ -373,7 +350,7 @@ class QueryBuilder
      */
     public function matchAll()
     {
-        return new MatchAll();
+        return new Elastica\Query\MatchAll();
     }
 
     /**
@@ -414,7 +391,7 @@ class QueryBuilder
      */
     public function missing($field = '')
     {
-        return new Missing($field);
+        return new Elastica\Query\Missing($field);
     }
 
     /**
@@ -434,7 +411,7 @@ class QueryBuilder
      */
     public function nested($path, $query)
     {
-        $nested = new Nested();
+        $nested = new Elastica\Query\Nested();
         $nested->setPath($path);
 
         $nested->setQuery($query);
@@ -451,7 +428,7 @@ class QueryBuilder
      */
     public function not($query)
     {
-        $boolQuery = new BoolQuery();
+        $boolQuery = new Elastica\Query\BoolQuery();
         $boolQuery->addMustNot($query);
         return $boolQuery;
     }
@@ -463,12 +440,12 @@ class QueryBuilder
      * @param string $field The field to query by.
      * @param string $prefix The prefix to check for.
      * @param float $boost The optional boost
-     * @return Prefix
+     * @return Query\Prefix
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
      */
     public function prefix($field, $prefix, $boost = 1.0)
     {
-        $prefixQuery = new Prefix;
+        $prefixQuery = new Elastica\Query\Prefix;
         $prefixQuery->setPrefix($field, $prefix, $boost);
         return $prefixQuery;
     }
@@ -491,7 +468,7 @@ class QueryBuilder
      */
     public function range($field, array $args)
     {
-        return new Range($field, $args);
+        return new Elastica\Query\Range($field, $args);
     }
 
     /**
@@ -511,7 +488,7 @@ class QueryBuilder
      */
     public function regexp($field, $regexp, array $options = [])
     {
-        return new Regexp($field, $regexp, $options);
+        return new Elastica\Query\Regexp($field, $regexp, $options);
     }
 
     /**
@@ -529,7 +506,7 @@ class QueryBuilder
      */
     public function script($script)
     {
-        return new Script($script);
+        return new Elastica\Query\Script($script);
     }
 
     /**
@@ -548,7 +525,7 @@ class QueryBuilder
      */
     public function term($field, $value)
     {
-        return new Term([$field => $value]);
+        return new Elastica\Query\Term([$field => $value]);
     }
 
     /**
@@ -567,7 +544,7 @@ class QueryBuilder
      */
     public function terms($field, $values)
     {
-        return new Terms($field, $values);
+        return new Elastica\Query\Terms($field, $values);
     }
 
     /**
@@ -585,7 +562,7 @@ class QueryBuilder
      */
     public function type($type)
     {
-        return new Type($type);
+        return new Elastica\Query\Type($type);
     }
 
     /**

--- a/tests/TestCase/QueryBuilderTest.php
+++ b/tests/TestCase/QueryBuilderTest.php
@@ -14,15 +14,15 @@
  */
 namespace Cake\ElasticSearch\Test;
 
-use Cake\ElasticSearch\FilterBuilder;
+use Cake\ElasticSearch\QueryBuilder;
 use Cake\TestSuite\TestCase;
 use Elastica\Filter;
 
 /**
- * Tests the FilterBuilder class
+ * Tests the QueryBuilder class
  *
  */
-class FilterBuilderTest extends TestCase
+class QueryBuilderTest extends TestCase
 {
 
     /**
@@ -32,7 +32,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testBetween()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->between('price', 10, 100);
         $expected = [
             'range' => ['price' => ['gte' => 10, 'lte' => 100]]
@@ -53,9 +53,9 @@ class FilterBuilderTest extends TestCase
      */
     public function testBool()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->bool();
-        $this->assertInstanceOf('Elastica\Filter\BoolFilter', $result);
+        $this->assertInstanceOf('Elastica\Query\BoolQuery', $result);
     }
 
     /**
@@ -65,7 +65,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testExists()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->exists('comments');
         $expected = [
             'exists' => ['field' => 'comments']
@@ -80,7 +80,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoBoundingBox()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoBoundingBox('location', [40.73, -74.1], [40.01, -71.12]);
         $expected = [
             'geo_bounding_box' => [
@@ -100,7 +100,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoDistance()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoDistance('location', ['lat' => 40.73, 'lon' => -74.1], '10km');
         $expected = [
             'geo_distance' => [
@@ -127,7 +127,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoDistanceRange()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoDistanceRange('location', ['lat' => 40.73, 'lon' => -74.1], '5km', '6km');
         $expected = [
             'geo_distance_range' => [
@@ -156,7 +156,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoPolygon()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoPolygon('location', [
             ['lat' => 40, 'lon' => -70],
             ['lat' => 30, 'lon' => -80],
@@ -183,7 +183,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoShape()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoShape('location', [
             ['lat' => 40, 'lon' => -70],
             ['lat' => 30, 'lon' => -80],
@@ -191,8 +191,8 @@ class FilterBuilderTest extends TestCase
         $expected = [
             'geo_shape' => [
                 'location' => [
-                    'relation' => 'intersects',
                     'shape' => [
+                        'relation' => 'intersects',
                         'type' => 'linestring',
                         'coordinates' => [
                             ['lat' => 40, 'lon' => -70],
@@ -212,7 +212,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoShapeIndex()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoShapeIndex('location', 'DEU', 'countries', 'shapes', 'location');
         $expected = [
             'geo_shape' => [
@@ -237,7 +237,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGeoHashCell()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->geoHashCell('location', ['lat' => 40.73, 'lon' => -74.1], 3);
         $expected = [
             'geohash_cell' => [
@@ -266,7 +266,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGt()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->gt('price', 10);
         $expected = [
             'range' => ['price' => ['gt' => 10]]
@@ -287,7 +287,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testGte()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->gte('price', 10);
         $expected = [
             'range' => ['price' => ['gte' => 10]]
@@ -308,12 +308,12 @@ class FilterBuilderTest extends TestCase
      */
     public function testHashChild()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->hasChild($builder->term('user', 'john'), 'comment');
         $expected = [
             'has_child' => [
                 'type' => 'comment',
-                'filter' => ['term' => ['user' => 'john']]
+                'query' => ['term' => ['user' => 'john']]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -326,12 +326,12 @@ class FilterBuilderTest extends TestCase
      */
     public function testHashParent()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->hasParent($builder->term('name', 'john'), 'user');
         $expected = [
             'has_parent' => [
                 'type' => 'user',
-                'filter' => ['term' => ['name' => 'john']]
+                'query' => ['term' => ['name' => 'john']]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -344,7 +344,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testIds()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->ids([1, 2, 3], 'user');
         $expected = [
             'ids' => [
@@ -362,7 +362,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testIndices()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->indices(
             ['a', 'b'],
             $builder->term('user', 'mark'),
@@ -371,8 +371,8 @@ class FilterBuilderTest extends TestCase
         $expected = [
             'indices' => [
                 'indices' => ['a', 'b'],
-                'filter' => ['term' => ['user' => 'mark']],
-                'no_match_filter' => ['term' => ['tag' => 'wow']]
+                'query' => ['term' => ['user' => 'mark']],
+                'no_match_query' => ['term' => ['tag' => 'wow']]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -385,7 +385,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testLimit()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->limit(10);
         $expected = [
             'limit' => ['value' => 10]
@@ -400,7 +400,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testMatchAll()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->matchAll();
         $expected = [
             'match_all' => new \stdClass
@@ -415,7 +415,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testLt()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->lt('price', 10);
         $expected = [
             'range' => ['price' => ['lt' => 10]]
@@ -436,7 +436,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testLte()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->lte('price', 10);
         $expected = [
             'range' => ['price' => ['lte' => 10]]
@@ -457,7 +457,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testMissing()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->missing('comments');
         $expected = [
             'missing' => ['field' => 'comments']
@@ -472,12 +472,12 @@ class FilterBuilderTest extends TestCase
      */
     public function testNested()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->nested('comments', $builder->term('author', 'mark'));
         $expected = [
             'nested' => [
                 'path' => 'comments',
-                'filter' => ['term' => ['author' => 'mark']]]
+                'query' => ['term' => ['author' => 'mark']]]
         ];
         $this->assertEquals($expected, $result->toArray());
     }
@@ -489,7 +489,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testNestedWithQuery()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->nested(
             'comments',
             new \Elastica\Query\SimpleQueryString('great')
@@ -509,11 +509,13 @@ class FilterBuilderTest extends TestCase
      */
     public function testNot()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->not($builder->term('title', 'cake'));
         $expected = [
-            'not' => [
-                'filter' => ['term' => ['title' => 'cake']]
+            'bool' => [
+                'must_not' => [
+                    ['term' => ['title' => 'cake']]
+                ]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -526,11 +528,25 @@ class FilterBuilderTest extends TestCase
      */
     public function testPrefix()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->prefix('user', 'ki');
         $expected = [
             'prefix' => [
-                'user' => 'ki'
+                'user' => [
+                    'value' => 'ki',
+                    'boost' => 1.0
+                ]
+            ]
+        ];
+        $this->assertEquals($expected, $result->toArray());
+
+        $result = $builder->prefix('user', 'ki', 2.0);
+        $expected = [
+            'prefix' => [
+                'user' => [
+                    'value' => 'ki',
+                    'boost' => 2.0
+                ]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -543,7 +559,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testQuery()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->query(new \Elastica\Query\SimpleQueryString('awesome'));
         $expected = [
             'query' => [
@@ -560,7 +576,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testRange()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->range('created', [
             'gte' => '2012-01-01',
             'lte' => 'now',
@@ -585,7 +601,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testRegexp()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->regexp('name.first', 'mar[c|k]', [
             'flags' => 'INTERSECTION|COMPLEMENT|EMPTY',
             'max_determinized_states' => 200
@@ -609,7 +625,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testScript()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->script("doc['foo'] > 2");
         $expected = [
             'script' => ['script' => "doc['foo'] > 2"]
@@ -624,7 +640,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testTerm()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->term('user.name', 'jose');
         $expected = [
             'term' => ['user.name' => 'jose']
@@ -639,7 +655,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testTerms()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->terms('user.name', ['mark', 'jose']);
         $expected = [
             'terms' => ['user.name' => ['mark', 'jose']]
@@ -654,7 +670,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testType()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->type('products');
         $expected = [
             'type' => ['value' => 'products']
@@ -669,11 +685,12 @@ class FilterBuilderTest extends TestCase
      */
     public function testAnd()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->and(
             $builder->term('user', 'jose'),
             $builder->gte('age', 29),
-            $builder->missing('tags')
+            $builder->missing('tags'),
+            $builder->and($builder->missing('missing'))
         );
         $expected = [
             'bool' => [
@@ -681,35 +698,7 @@ class FilterBuilderTest extends TestCase
                     ['term' => ['user' => 'jose']],
                     ['range' => ['age' => ['gte' => 29]]],
                     ['missing' => ['field' => 'tags']],
-                ]
-            ]
-        ];
-        $this->assertEquals($expected, $result->toArray());
-    }
-
-    /**
-     * Tests the and() method with boolean collapsing
-     *
-     * @return void
-     */
-    public function testAndWithCollapsedBoolean()
-    {
-        $builder = new FilterBuilder;
-        $result = $builder->and(
-            $builder->term('user', 'jose'),
-            $builder->gte('age', 29),
-            $builder->and(
-                $builder->missing('tags'),
-                $builder->exists('comments')
-            )
-        );
-        $expected = [
-            'bool' => [
-                'must' => [
-                    ['missing' => ['field' => 'tags']],
-                    ['exists' => ['field' => 'comments']],
-                    ['term' => ['user' => 'jose']],
-                    ['range' => ['age' => ['gte' => 29]]],
+                    ['bool' => ['must' => [['missing' => ['field' => 'missing']]]]]
                 ]
             ]
         ];
@@ -723,17 +712,19 @@ class FilterBuilderTest extends TestCase
      */
     public function testOr()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $result = $builder->or(
             $builder->term('user', 'jose'),
             $builder->gte('age', 29),
             $builder->missing('tags')
         );
         $expected = [
-            'or' => [
-                ['term' => ['user' => 'jose']],
-                ['range' => ['age' => ['gte' => 29]]],
-                ['missing' => ['field' => 'tags']],
+            'bool' => [
+                'should' => [
+                        ['term' => ['user' => 'jose']],
+                        ['range' => ['age' => ['gte' => 29]]],
+                        ['missing' => ['field' => 'tags']],
+                ]
             ]
         ];
         $this->assertEquals($expected, $result->toArray());
@@ -746,7 +737,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testParseSingleArray()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $filter = $builder->parse([
             'name' => 'jose',
             'age >=' => 29,
@@ -785,7 +776,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testParseOr()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $filter = $builder->parse([
             'or' => [
                 'name' => 'jose',
@@ -808,7 +799,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testParseAnd()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $filter = $builder->parse([
             'and' => [
                 'name' => 'jose',
@@ -831,7 +822,7 @@ class FilterBuilderTest extends TestCase
      */
     public function testParseNot()
     {
-        $builder = new FilterBuilder;
+        $builder = new QueryBuilder;
         $filter = $builder->parse([
             'not' => [
                 'name' => 'jose',

--- a/tests/TestCase/QueryBuilderTest.php
+++ b/tests/TestCase/QueryBuilderTest.php
@@ -553,23 +553,6 @@ class QueryBuilderTest extends TestCase
     }
 
     /**
-     * Tests the query() filter
-     *
-     * @return void
-     */
-    public function testQuery()
-    {
-        $builder = new QueryBuilder;
-        $result = $builder->query(new \Elastica\Query\SimpleQueryString('awesome'));
-        $expected = [
-            'query' => [
-                'simple_query_string' => ['query' => 'awesome']
-            ]
-        ];
-        $this->assertEquals($expected, $result->toArray());
-    }
-
-    /**
      * Tests the range() filter
      *
      * @return void

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -393,8 +393,6 @@ class QueryTest extends TestCase
 
         $compiled = $query->compileQuery()->toArray();
 
-        print_r($compiled);
-
         $filter = $compiled['post_filter']['bool']['must'];
 
         $expected = ['term' => ['name.first' => 'jose']];

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\ElasticSearch\Test;
 
-use Cake\ElasticSearch\FilterBuilder;
+use Cake\ElasticSearch\QueryBuilder;
 use Cake\ElasticSearch\Query;
 use Cake\ElasticSearch\Type;
 use Cake\TestSuite\TestCase;
@@ -238,9 +238,9 @@ class QueryTest extends TestCase
             '_source' => ['id', 'name'],
             'size' => 10,
             'query' => [
-                'filtered' => [
+                'bool' => [
                     'filter' => [
-                        'bool' => [
+                        ['bool' => [
                             'must' => [[
                                 'range' => [
                                     'created' => [
@@ -248,7 +248,7 @@ class QueryTest extends TestCase
                                     ]
                                 ]
                             ]]
-                        ]
+                        ]]
                     ]
                 ]
             ]
@@ -329,7 +329,8 @@ class QueryTest extends TestCase
         ]);
 
         $compiled = $query->compileQuery()->toArray();
-        $filter = $compiled['query']['filtered']['filter']['bool']['must'];
+
+        $filter = $compiled['query']['bool']['filter'][0]['bool']['must'];
 
         $expected = ['term' => ['name.first' => 'jose']];
         $this->assertEquals($expected, $filter[0]);
@@ -338,18 +339,18 @@ class QueryTest extends TestCase
         $this->assertEquals($expected, $filter[1]);
 
         $expected = ['terms' => ['tags' => ['cake', 'php']]];
-        $this->assertEquals($expected, $filter[2]['or'][0]);
+        $this->assertEquals($expected, $filter[2]['bool']['should'][0]);
 
         $expected = [
-            'not' => [
-                'filter' => [
-                    'terms' => ['interests' => ['c#', 'java']]
+            'bool' => [
+                'must_not' => [
+                    ['terms' => ['interests' => ['c#', 'java']]]
                 ]
             ]
         ];
-        $this->assertEquals($expected, $filter[2]['or'][1]);
+        $this->assertEquals($expected, $filter[2]['bool']['should'][1]);
 
-        $query->where(function (FilterBuilder $builder) {
+        $query->where(function (QueryBuilder $builder) {
             return $builder->and(
                 $builder->term('another.thing', 'value'),
                 $builder->exists('stuff')
@@ -357,7 +358,7 @@ class QueryTest extends TestCase
         });
 
         $compiled = $query->compileQuery()->toArray();
-        $filter = $compiled['query']['filtered']['filter']['bool']['must'];
+        $filter = $compiled['query']['bool']['filter'][0]['bool']['must'];
         $filter = $filter[3]['bool']['must'];
         $expected = [
             ['term' => ['another.thing' => 'value']],
@@ -367,7 +368,7 @@ class QueryTest extends TestCase
 
         $query->where(['name.first' => 'jose'], true);
         $compiled = $query->compileQuery()->toArray();
-        $filter = $compiled['query']['filtered']['filter']['bool']['must'];
+        $filter = $compiled['query']['bool']['filter'][0]['bool']['must'];
         $expected = ['term' => ['name.first' => 'jose']];
         $this->assertEquals([$expected], $filter);
     }
@@ -391,6 +392,9 @@ class QueryTest extends TestCase
         ]);
 
         $compiled = $query->compileQuery()->toArray();
+
+        print_r($compiled);
+
         $filter = $compiled['post_filter']['bool']['must'];
 
         $expected = ['term' => ['name.first' => 'jose']];
@@ -400,18 +404,18 @@ class QueryTest extends TestCase
         $this->assertEquals($expected, $filter[1]);
 
         $expected = ['terms' => ['tags' => ['cake', 'php']]];
-        $this->assertEquals($expected, $filter[2]['or'][0]);
+        $this->assertEquals($expected, $filter[2]['bool']['should'][0]);
 
         $expected = [
-            'not' => [
-                'filter' => [
-                    'terms' => ['interests' => ['c#', 'java']]
-                ]
+            'bool' => [
+                'must_not' => [
+                        ['terms' => ['interests' => ['c#', 'java']]]
+                ]                
             ]
         ];
-        $this->assertEquals($expected, $filter[2]['or'][1]);
+        $this->assertEquals($expected, $filter[2]['bool']['should'][1]);
 
-        $query->postFilter(function (FilterBuilder $builder) {
+        $query->postFilter(function (QueryBuilder $builder) {
             return $builder->and(
                 $builder->term('another.thing', 'value'),
                 $builder->exists('stuff')

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -556,6 +556,10 @@ class TypeTest extends TestCase
     public function testDeleteAll()
     {
         $result = $this->type->deleteAll(['title' => 'article']);
+
+        //TODO : Not Sure
+        ConnectionManager::get('test')->getIndex()->refresh();
+
         $this->assertTrue($result);
         $this->assertEquals(0, $this->type->find()->count());
     }
@@ -568,6 +572,10 @@ class TypeTest extends TestCase
     public function testDeleteAllOnlySome()
     {
         $result = $this->type->deleteAll(['body' => 'cake']);
+        
+        //TODO : Not Sure
+        ConnectionManager::get('test')->getIndex()->refresh();
+
         $this->assertTrue($result);
         $this->assertEquals(1, $this->type->find()->count());
     }


### PR DESCRIPTION
I'm not sure what we should do for the `->query` method. We can't predict what the user will pass and we need a bool query for simple filter.

And I'm not sure why there isn't options anymore on regex query on elastica. In the doc there is flags https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html. 

I've also temporarily addedan index refresh in delete tests. https://www.elastic.co/guide/en/elasticsearch/plugins/2.0/delete-by-query-plugin-reason.html . Seems to be needed now

