### PR TITLE
Working towards supporting should and must_not clauses

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -321,7 +321,7 @@ class Query implements IteratorAggregate
      * @param bool $overwrite Whether or not to replace previous queries.
      * @return Query
      */
-    public function query($conditions, $overwrite = false)
+    public function queryMust($conditions, $overwrite = false)
     {
         return $this->_buildBoolQuery('query', $conditions, $overwrite);
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -188,12 +188,9 @@ class Query implements IteratorAggregate
      * integers. This is summary of the return types for each clause.
      *
      * - fields: array, will return empty array when no fields are set
-     * - must: The list of queries to be added to the "must" part of the BoolQuery
-     * - should: The list of queries to be added to the "should" part of the BoolQuery
-     * - mustNot: The list of queries to be added to the "must_not" part of the BoolQuery
+     * - query: The final BoolQuery to be used in the query (with scoring) part.
      * - filter: The query to use in the final BoolQuery filter object, returns null when not set
      * - postFilter: The query to use in the post_filter object, returns null when not set
-     * - query: Raw query (Elastica\Query\AbstractQuery), return null when not set
      * - order: OrderByExpression, returns null when not set
      * - limit: integer, null when not set
      * - offset: integer, null when not set
@@ -266,6 +263,9 @@ class Query implements IteratorAggregate
     /**
      * Sets the filter to use in the query object. Queries added using this method
      * will be stacked on a bool query and applied to the filter part of the final BoolQuery.
+     *
+     * Filters added with this method will have no effect in the final score of the documents,
+     * and the documents that do not match the specified filters will be left out.
      *
      * There are several way in which you can use this method. The easiest one is by passing
      * a simple array of conditions:

--- a/src/Query.php
+++ b/src/Query.php
@@ -321,7 +321,7 @@ class Query implements IteratorAggregate
      * @param bool $overwrite Whether or not to replace previous queries.
      * @return Query
      */
-    public function search($conditions, $overwrite = false)
+    public function query($conditions, $overwrite = false)
     {
         return $this->_buildBoolQuery('query', $conditions, $overwrite);
     }
@@ -349,7 +349,7 @@ class Query implements IteratorAggregate
      * @param AbstractQuery $query Set the query
      * @return $this
      */
-    public function query(AbstractQuery $query)
+    public function setFullQuery(AbstractQuery $query)
     {
         $this->_queryParts['query'] = $query;
         return $this;

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -51,60 +51,6 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests that executing a query means executing a search against the associated
-     * Type and decorates the internal ResultSet
-     *
-     * @return void
-     */
-    public function testAll()
-    {
-        $connection = $this->getMock(
-            'Cake\ElasticSearch\Datasource\Connection',
-            ['getIndex']
-        );
-        $type = new Type([
-            'name' => 'foo',
-            'connection' => $connection
-        ]);
-
-        $index = $this->getMockBuilder('Elastica\Index')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $internalType = $this->getMockBuilder('Elastica\Type')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $connection->expects($this->once())
-            ->method('getIndex')
-            ->will($this->returnValue($index));
-
-        $index->expects($this->once())
-            ->method('getType')
-            ->will($this->returnValue($internalType));
-
-        $result = $this->getMockBuilder('Elastica\ResultSet')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $internalQuery = $this->getMockBuilder('Elastica\Query')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $internalType->expects($this->once())
-            ->method('search')
-            ->will($this->returnCallback(function ($query) use ($result) {
-                $this->assertEquals(new \Elastica\Query, $query);
-                return $result;
-            }));
-
-        $query = new Query($type);
-        $resultSet = $query->all();
-        $this->assertInstanceOf('Cake\ElasticSearch\ResultSet', $resultSet);
-        $this->assertSame($result, $resultSet->getInnerIterator());
-    }
-
-    /**
      * Test that query overwrite any query
      */
     public function testQuery()
@@ -414,7 +360,7 @@ class QueryTest extends TestCase
 
         $compiled = $query->compileQuery()->toArray();
 
-        $must = $compiled['query']['bool']['must'][0]['bool']['must'];
+        $must = $compiled['query']['bool']['must'];
 
         $expected = ['term' => ['name.first' => 'jose']];
         $this->assertEquals($expected, $must[0]);
@@ -442,7 +388,7 @@ class QueryTest extends TestCase
         });
 
         $compiled = $query->compileQuery()->toArray();
-        $must = $compiled['query']['bool']['must'][0]['bool']['must'];
+        $must = $compiled['query']['bool']['must'];
         $must = $must[3]['bool']['must'];
         $expected = [
             ['term' => ['another.thing' => 'value']],
@@ -452,7 +398,7 @@ class QueryTest extends TestCase
 
         $query->search(['name.first' => 'jose'], true);
         $compiled = $query->compileQuery()->toArray();
-        $must = $compiled['query']['bool']['must'][0]['bool']['must'];
+        $must = $compiled['query']['bool']['must'];
         $expected = ['term' => ['name.first' => 'jose']];
         $this->assertEquals([$expected], $must);
     }

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -53,14 +53,14 @@ class QueryTest extends TestCase
     /**
      * Test that query overwrite any query
      */
-    public function testQuery()
+    public function testSetFullQuery()
     {
         $type = new Type();
         $query = new Query($type);
 
         $query
             ->where(['name' => 'test'])
-            ->query(new \Elastica\Query\Term(['name' => 'cake']));
+            ->setFullQuery(new \Elastica\Query\Term(['name' => 'cake']));
 
         $expected = ['query' => [
             'term' => [
@@ -345,11 +345,11 @@ class QueryTest extends TestCase
      *
      * @return void
      */
-    public function testQuery()
+    public function testQueryMust()
     {
         $type = new Type();
         $query = new Query($type);
-        $query->query([
+        $query->queryMust([
             'name.first' => 'jose',
             'age >' => 29,
             'or' => [
@@ -380,7 +380,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $must[2]['bool']['should'][1]);
 
-        $query->query(function (QueryBuilder $builder) {
+        $query->queryMust(function (QueryBuilder $builder) {
             return $builder->and(
                 $builder->term('another.thing', 'value'),
                 $builder->exists('stuff')
@@ -396,7 +396,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $must);
 
-        $query->query(['name.first' => 'jose'], true);
+        $query->queryMust(['name.first' => 'jose'], true);
         $compiled = $query->compileQuery()->toArray();
         $must = $compiled['query']['bool']['must'];
         $expected = ['term' => ['name.first' => 'jose']];

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -341,15 +341,15 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests the search() method
+     * Tests the query() method
      *
      * @return void
      */
-    public function testSearch()
+    public function testQuery()
     {
         $type = new Type();
         $query = new Query($type);
-        $query->search([
+        $query->query([
             'name.first' => 'jose',
             'age >' => 29,
             'or' => [
@@ -380,7 +380,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $must[2]['bool']['should'][1]);
 
-        $query->search(function (QueryBuilder $builder) {
+        $query->query(function (QueryBuilder $builder) {
             return $builder->and(
                 $builder->term('another.thing', 'value'),
                 $builder->exists('stuff')
@@ -396,7 +396,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $must);
 
-        $query->search(['name.first' => 'jose'], true);
+        $query->query(['name.first' => 'jose'], true);
         $compiled = $query->compileQuery()->toArray();
         $must = $compiled['query']['bool']['must'];
         $expected = ['term' => ['name.first' => 'jose']];


### PR DESCRIPTION
This simplifies the way we store the main wrapper BoolQuery, and sets the foundation for supporting should and must_not clauses.

Open Questions:

* What is a good naming for adding `should` and `must_not` clauses?
* Is `search()` actually a good name?
* How do we communicate to newcomers the differences between `where()` and `search()` and the methods are are to come?