### PR TITLE
Fix missing logger instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ a connection:
     ]
 ```
 
+You can enable request logging by setting the `log` config option to true. By
+default, `Elastica\Log` will be used, which logs via `error_log`. You can also
+define an `elasticsearch` log profile in `Cake\Log\Log` to customize where
+elasticsearch query logs will go. Query logging is done at a 'debug' level.
+
 ## Getting a Type object
 
 Type objects are the equivalent of `ORM\Table` instances in elastic search. You can

--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -16,7 +16,9 @@ namespace Cake\ElasticSearch\Datasource;
 
 use Cake\Database\Log\LoggedQuery;
 use Cake\Datasource\ConnectionInterface;
+use Cake\Log\Log;
 use Elastica\Client;
+use Elastica\Log as ElasticaLog;
 use Elastica\Request;
 
 class Connection extends Client implements ConnectionInterface
@@ -181,6 +183,9 @@ class Connection extends Client implements ConnectionInterface
         if (!$this->logQueries) {
             return;
         }
+        if (!isset($this->_logger)) {
+            $this->_logger = Log::engine('elasticsearch') ?: new ElasticaLog();
+        }
 
         if ($context instanceof Request) {
             $data = $context->toArray();
@@ -196,6 +201,6 @@ class Connection extends Client implements ConnectionInterface
         $data = json_encode($logData, JSON_PRETTY_PRINT);
         $loggedQuery = new LoggedQuery();
         $loggedQuery->query = $data;
-        $this->_logger->log($loggedQuery);
+        $this->_logger->log('debug', $loggedQuery);
     }
 }

--- a/tests/TestCase/Datasource/ConnectionTest.php
+++ b/tests/TestCase/Datasource/ConnectionTest.php
@@ -15,6 +15,8 @@
 namespace Cake\ElasticSearch\Test\Datasource;
 
 use Cake\ElasticSearch\Datasource\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -61,5 +63,24 @@ class ConnectionTest extends TestCase
         $opts = ['log' => true];
         $connection = new Connection($opts);
         $this->assertTrue($connection->logQueries());
+    }
+
+    /**
+     * Ensure that logging queries works.
+     *
+     * @return void
+     */
+    public function testQueryLogging()
+    {
+        $logger = $this->getMock('Cake\Log\Engine\BaseLog', ['log']);
+        $logger->expects($this->once())->method('log');
+        Log::config('elasticsearch', $logger);
+
+        $connection = ConnectionManager::get('test');
+        $connection->logQueries(true);
+        $result = $connection->request('_stats');
+        $connection->logQueries(false);
+
+        $this->assertNotEmpty($result);
     }
 }


### PR DESCRIPTION
Default to the `Elastica\Log` object if no logging profile is defined. This makes our wrappers do what `Elastica` would naturally do when configured in a naive way.

Refs #94