### PR TITLE
Fix event usage.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,22 +17,22 @@ use Cake\Event\EventManager;
 use Cake\ElasticSearch\Document;
 use Cake\ElasticSearch\View\Form\DocumentContext;
 
-// Attach the TypeRegistry into controllers.
-EventManager::instance()->on(
-    'Dispatcher.beforeDispatch',
-    ['priority' => 99],
-    function ($event) {
-        $controller = false;
-        if (isset($event->data['controller'])) {
-            $controller = $event->data['controller'];
-        }
-        if ($controller) {
-            $callback = ['Cake\ElasticSearch\TypeRegistry', 'get'];
-            $controller->modelFactory('ElasticSearch', $callback);
-            $controller->modelFactory('Elastic', $callback);
-        }
+$listener = function ($event) {
+    $controller = false;
+    if (isset($event->data['controller'])) {
+        $controller = $event->data['controller'];
     }
-);
+    if ($controller) {
+        $callback = ['Cake\ElasticSearch\TypeRegistry', 'get'];
+        $controller->modelFactory('ElasticSearch', $callback);
+        $controller->modelFactory('Elastic', $callback);
+    }
+};
+
+// Attach the TypeRegistry into controllers.
+EventManager::instance()->on('Dispatcher.invokeController', $listener);
+EventManager::instance()->on('Dispatcher.beforeDispatch', ['priority' => 99], $listener);
+unset($listener);
 
 // Attach the document context into FormHelper.
 EventManager::instance()->on('View.beforeRender', function ($event) {

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -95,6 +95,7 @@ class QueryTest extends TestCase
             ->method('search')
             ->will($this->returnCallback(function ($query) use ($result) {
                 $this->assertEquals(new \Elastica\Query, $query);
+
                 return $result;
             }));
 

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -49,6 +49,7 @@ class ResultSetTest extends TestCase
             ->will($this->returnValue(__NAMESPACE__ . '\MyTestDocument'));
         $type->method('embedded')
             ->will($this->returnValue([]));
+
         return [new ResultSet($elasticaSet, $query), $elasticaSet];
     }
 

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -324,6 +324,7 @@ class TypeTest extends TestCase
         $doc->title = 'new title';
         $this->type->eventManager()->on('Model.beforeSave', function ($event, $entity, $options) use ($doc) {
             $event->stopPropagation();
+
             return 'kaboom';
         });
         $this->type->eventManager()->on('Model.afterSave', function () {
@@ -505,6 +506,7 @@ class TypeTest extends TestCase
         $doc = $this->type->get(1);
         $this->type->eventManager()->on('Model.beforeDelete', function ($event, $entity, $options) use ($doc) {
             $event->stopPropagation();
+
             return 'kaboom';
         });
         $this->type->eventManager()->on('Model.afterDelete', function () {


### PR DESCRIPTION
Use Dispatcher.invokeController as it works more consistently between various versions of CakePHP. In 3.3+ `Dispatcher.beforeDispatch` doesn't always have access to the Controller depending on how the application is setup.

Refs #109