### PR TITLE
Add method for getting elastica query object

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -356,6 +356,16 @@ class Query implements IteratorAggregate
     }
 
     /**
+     * Return the current Elastica query
+     *
+     * @return \Elastica\Query
+     */
+    public function getElasticQuery()
+    {
+        return $this->_elasticQuery;
+    }
+
+    /**
      * Add an aggregation to the elastic query object
      *
      * @param  array|\Elastica\Aggregation\AbstractAggregation $aggregation One or multiple facets

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -18,6 +18,7 @@ use Cake\ElasticSearch\Query;
 use Cake\ElasticSearch\QueryBuilder;
 use Cake\ElasticSearch\Type;
 use Cake\TestSuite\TestCase;
+use Elastica\Query as ElasticaQuery;
 
 /**
  * Tests the Query class
@@ -69,6 +70,17 @@ class QueryTest extends TestCase
         ]];
 
         $this->assertSame($expected, $query->compileQuery()->toArray());
+    }
+
+    /**
+     * Test we get instance of elastica query
+     */
+    public function testGetElasticQuery()
+    {
+        $type = new Type();
+        $query = new Query($type);
+
+        $this->assertInstanceOf(ElasticaQuery::class, $query->getElasticQuery());
     }
 
     /**


### PR DESCRIPTION
Possible to get a hold on the elastica query object without compiling it.