### PR TITLE
Listen for events

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -122,6 +122,7 @@ class Type implements RepositoryInterface, EventListenerInterface, EventDispatch
         }
         $this->_eventManager = $eventManager ?: new EventManager();
         $this->initialize($config);
+        $this->_eventManager->on($this);
         $this->dispatchEvent('Model.initialize');
     }
 

--- a/tests/TestCase/TypeTest.php
+++ b/tests/TestCase/TypeTest.php
@@ -666,4 +666,18 @@ class TypeTest extends TestCase
         ];
         $this->assertEquals($expected, $result, 'Events do not match.');
     }
+
+    /**
+     * Test that type listen's to it's own events..
+     *
+     * @return void
+     */
+    public function testOwnEvents()
+    {
+        $type = $this->getMockBuilder('Cake\ElasticSearch\Type')
+            ->setMethods(['beforeSave'])
+            ->getMock();
+
+        $this->assertCount(1, $type->eventManager()->listeners('Model.beforeSave'));
+    }
 }


### PR DESCRIPTION
Type objects should be bound to their own event manager.