### PR TITLE
Fix use of deprecated methods

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -372,7 +372,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getType()
     {
         if ($this->_type === null) {
-            $this->_type = $this->getName();
+            $this->_type = Inflector::singularize($this->getName());
         }
 
         return $this->_type;
@@ -613,7 +613,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             $entities[$key]->id = $doc->getId();
             $entities[$key]->_version = $doc->getVersion();
             $entities[$key]->isNew(false);
-            $entities[$key]->source($this->getType());
+            $entities[$key]->source($this->getName());
             $entities[$key]->clean();
 
             $this->dispatchEvent('Model.afterSave', [
@@ -677,7 +677,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         $entity->id = $doc->getId();
         $entity->_version = $doc->getVersion();
         $entity->isNew(false);
-        $entity->source($this->getType());
+        $entity->source($this->getName());
         $entity->clean();
 
         $this->dispatchEvent('Model.afterSave', [

--- a/src/Index.php
+++ b/src/Index.php
@@ -311,7 +311,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function table()
     {
-        return $this->name();
+        return $this->getName();
     }
 
     /**
@@ -336,9 +336,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function setAlias($alias)
     {
-        $this->name($alias);
-
-        return $this;
+        return $this->setName($alias);
     }
 
     /**
@@ -348,7 +346,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function getAlias()
     {
-        return $this->name();
+        return $this->getName();
     }
 
     /**
@@ -454,7 +452,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function get($primaryKey, $options = [])
     {
-        $type = $this->connection()->getIndex($this->getName())->getType($this->getType());
+        $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $result = $type->getDocument($primaryKey, $options);
         $class = $this->entityClass();
 
@@ -462,7 +460,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             'markNew' => false,
             'markClean' => true,
             'useSetters' => false,
-            'source' => $this->name(),
+            'source' => $this->getName(),
         ];
         $data = $result->getData();
         $data['id'] = $result->getId();
@@ -528,7 +526,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $query = $this->query();
         $query->where($conditions);
-        $type = $this->connection()->getIndex($this->getName())->getType($this->getType());
+        $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $response = $type->deleteByQuery($query->compileQuery());
 
         return $response->isOk();
@@ -608,7 +606,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             $documents[$key] = $doc;
         }
 
-        $type = $this->connection()->getIndex($this->getName())->getType($this->getType());
+        $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $type->addDocuments($documents);
 
         foreach ($documents as $key => $document) {
@@ -665,7 +663,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             return false;
         }
 
-        $type = $this->connection()->getIndex($this->getName())->getType($this->getType());
+        $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $id = $entity->id ?: null;
 
         $data = $entity->toArray();
@@ -728,7 +726,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $doc = new ElasticaDocument($entity->id, $data);
 
-        $type = $this->connection()->getIndex($this->getName())->getType($this->getType());
+        $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $result = $type->deleteDocument($doc);
 
         $this->dispatchEvent('Model.afterDelete', [
@@ -762,7 +760,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($data === null) {
             $class = $this->entityClass();
 
-            return new $class([], ['source' => $this->name()]);
+            return new $class([], ['source' => $this->getName()]);
         }
 
         return $this->marshaller()->one($data, $options);
@@ -891,7 +889,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $this->schema;
         }
         $index = $this->getName();
-        $type = $this->connection()->getIndex($index)->getType($this->getType());
+        $type = $this->getConnection()->getIndex($index)->getType($this->getType());
         $this->schema = new MappingSchema($this->getType(), $type->getMapping());
 
         return $this->schema;

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -61,7 +61,7 @@ class Marshaller
     {
         $entityClass = $this->index->entityClass();
         $entity = new $entityClass();
-        $entity->source($this->index->name());
+        $entity->source($this->index->getName());
         $options += ['associated' => []];
 
         list($data, $options) = $this->_prepareDataAndOptions($data, $options);

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -70,7 +70,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
             $this->embeds[$embed->property()] = $embed;
         }
         $this->entityClass = $repo->entityClass();
-        $this->repoName = $repo->name();
+        $this->repoName = $repo->getName();
         parent::__construct($resultSet);
     }
 

--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -16,6 +16,7 @@ namespace Cake\ElasticSearch\TestSuite;
 
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\FixtureInterface;
+use Cake\Utility\Inflector;
 use Elastica\Query\MatchAll;
 use Elastica\Type\Mapping as ElasticaMapping;
 
@@ -86,7 +87,7 @@ class TestFixture implements FixtureInterface
         }
         $index->create();
 
-        $type = $index->getType($this->table);
+        $type = $index->getType(Inflector::singularize($this->table));
         $mapping = new ElasticaMapping();
         $mapping->setType($type);
         $mapping->setProperties($this->schema);
@@ -122,7 +123,7 @@ class TestFixture implements FixtureInterface
         }
         $documents = [];
         $index = $db->getIndex($this->table);
-        $type = $index->getType($this->table);
+        $type = $index->getType(Inflector::singularize($this->table));
 
         foreach ($this->records as $data) {
             $id = '';
@@ -161,7 +162,7 @@ class TestFixture implements FixtureInterface
     {
         $query = new MatchAll();
         $index = $db->getIndex($this->table);
-        $type = $index->getType($this->table);
+        $type = $index->getType(Inflector::singularize($this->table));
         $type->deleteByQuery($query);
         $index->refresh();
     }

--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -43,7 +43,7 @@ class DocumentContext implements ContextInterface
     protected $_context;
 
     /**
-     * The name of the top level entity/type object.
+     * The name of the top level entity/index object.
      *
      * @var string
      */
@@ -68,7 +68,7 @@ class DocumentContext implements ContextInterface
         $this->_request = $request;
         $context += [
             'entity' => null,
-            'type' => null,
+            'index' => null,
             'validator' => 'default',
         ];
         $this->_context = $context;
@@ -81,9 +81,9 @@ class DocumentContext implements ContextInterface
      * If the table option was provided to the constructor and it
      * was a string, IndexRegistry will be used to get the correct table instance.
      *
-     * If an object is provided as the type option, it will be used as is.
+     * If an object is provided as the index option, it will be used as is.
      *
-     * If no type option is provided, the type name will be derived based on
+     * If no index option is provided, the index name will be derived based on
      * naming conventions. This inference will work with a number of common objects
      * like arrays, Collection objects and ResultSets.
      *
@@ -92,37 +92,37 @@ class DocumentContext implements ContextInterface
      */
     protected function _prepare()
     {
-        $type = $this->_context['type'];
+        $index = $this->_context['index'];
         $entity = $this->_context['entity'];
-        if (empty($type)) {
+        if (empty($index)) {
             if (is_array($entity) || $entity instanceof Traversable) {
                 $entity = (new Collection($entity))->first();
             }
             $isDocument = $entity instanceof Document;
 
             if ($isDocument) {
-                $type = $entity->source();
+                $index = $entity->source();
             }
-            if (!$type && $isDocument && get_class($entity) !== 'Cake\ElasticSearch\Document') {
+            if (!$index && $isDocument && get_class($entity) !== 'Cake\ElasticSearch\Document') {
                 list(, $entityClass) = namespaceSplit(get_class($entity));
-                $type = Inflector::pluralize($entityClass);
+                $index = Inflector::pluralize($entityClass);
             }
         }
-        if (is_string($type)) {
-            $type = IndexRegistry::get($type);
+        if (is_string($index)) {
+            $index = IndexRegistry::get($index);
         }
 
-        if (!is_object($type)) {
+        if (!is_object($index)) {
             throw new RuntimeException(
-                'Unable to find type class for current entity'
+                'Unable to find index class for current entity'
             );
         }
         $this->_isCollection = (
             is_array($entity) ||
             $entity instanceof Traversable
         );
-        $this->_rootName = $type->name();
-        $this->_context['type'] = $type;
+        $this->_rootName = $index->getName();
+        $this->_context['index'] = $index;
     }
 
     /**
@@ -291,13 +291,13 @@ class DocumentContext implements ContextInterface
     }
 
     /**
-     * Get the validator for the current type.
+     * Get the validator for the current index.
      *
-     * @return \Cake\Validation\Validator The validator for the type.
+     * @return \Cake\Validation\Validator The validator for the index.
      */
     protected function getValidator()
     {
-        return $this->_context['type']->validator($this->_context['validator']);
+        return $this->_context['index']->validator($this->_context['validator']);
     }
 
     /**
@@ -305,7 +305,7 @@ class DocumentContext implements ContextInterface
      */
     public function fieldNames()
     {
-        $schema = $this->_context['type']->schema();
+        $schema = $this->_context['index']->schema();
 
         return $schema->fields();
     }
@@ -315,7 +315,7 @@ class DocumentContext implements ContextInterface
      */
     public function type($field)
     {
-        $schema = $this->_context['type']->schema();
+        $schema = $this->_context['index']->schema();
 
         return $schema->fieldType($field);
     }

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -29,7 +29,7 @@ class EmbeddedDocumentTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->type = new Index([
+        $this->index = new Index([
             'name' => 'profiles',
             'connection' => ConnectionManager::get('test')
         ]);
@@ -42,8 +42,8 @@ class EmbeddedDocumentTest extends TestCase
      */
     public function testEmbedOne()
     {
-        $this->assertNull($this->type->embedOne('Address'));
-        $assocs = $this->type->embedded();
+        $this->assertNull($this->index->embedOne('Address'));
+        $assocs = $this->index->embedded();
         $this->assertCount(1, $assocs);
         $this->assertEquals('\Cake\ElasticSearch\Document', $assocs[0]->entityClass());
         $this->assertEquals('address', $assocs[0]->property());
@@ -56,8 +56,8 @@ class EmbeddedDocumentTest extends TestCase
      */
     public function testGetWithEmbedOne()
     {
-        $this->type->embedOne('Address');
-        $result = $this->type->get(1);
+        $this->index->embedOne('Address');
+        $result = $this->index->get(1);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address);
         $this->assertEquals('123 street', $result->address->street);
     }
@@ -69,8 +69,8 @@ class EmbeddedDocumentTest extends TestCase
      */
     public function testFindWithEmbedOne()
     {
-        $this->type->embedOne('Address');
-        $result = $this->type->find()->where(['username' => 'mark']);
+        $this->index->embedOne('Address');
+        $result = $this->index->find()->where(['username' => 'mark']);
         $rows = $result->toArray();
         $this->assertCount(1, $rows);
     }
@@ -82,8 +82,8 @@ class EmbeddedDocumentTest extends TestCase
      */
     public function testGetWithEmbedMany()
     {
-        $this->type->embedMany('Address');
-        $result = $this->type->get(3);
+        $this->index->embedMany('Address');
+        $result = $this->index->get(3);
         $this->assertInternalType('array', $result->address);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address[0]);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address[1]);
@@ -96,8 +96,8 @@ class EmbeddedDocumentTest extends TestCase
      */
     public function testFindWithEmbedMany()
     {
-        $this->type->embedMany('Address');
-        $result = $this->type->find()->where(['username' => 'sara']);
+        $this->index->embedMany('Address');
+        $result = $this->index->find()->where(['username' => 'sara']);
         $rows = $result->toArray();
 
         $this->assertCount(1, $rows);

--- a/tests/TestCase/IndexRegistryTest.php
+++ b/tests/TestCase/IndexRegistryTest.php
@@ -71,7 +71,7 @@ class IndexRegistryTest extends TestCase
         $this->assertFalse(IndexRegistry::exists('Comments'));
         $this->assertFalse(IndexRegistry::exists('TestPlugin.Comments'));
 
-        IndexRegistry::get('TestPlugin.Comments', ['type' => 'comments']);
+        IndexRegistry::get('TestPlugin.Comments', ['name' => 'comments']);
         $this->assertFalse(IndexRegistry::exists('Comments'), 'The Comments key should not be populated');
         $this->assertTrue(IndexRegistry::exists('TestPlugin.Comments'), 'The plugin.alias key should now be populated');
     }

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -654,8 +654,8 @@ class IndexTest extends TestCase
      */
     public function testAlias()
     {
-        $this->assertEquals($this->index->name(), $this->index->alias());
-        $this->assertEquals('articles', $this->index->alias());
+        $this->assertEquals($this->index->getName(), $this->index->getAlias());
+        $this->assertEquals('articles', $this->index->getAlias());
     }
 
     /**

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -52,7 +52,7 @@ class MarshallerTest extends TestCase
     {
         parent::setUp();
         $connection = ConnectionManager::get('test');
-        $this->type = new Index([
+        $this->index = new Index([
             'connection' => $connection,
             'name' => 'articles',
         ]);
@@ -70,7 +70,7 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -91,10 +91,10 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $this->type->validator()
+        $this->index->validator()
             ->add('title', 'numbery', ['rule' => 'numeric']);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -116,7 +116,7 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data, ['fieldList' => ['title']]);
 
         $this->assertSame($data['title'], $result->title);
@@ -136,9 +136,9 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $this->type->entityClass(__NAMESPACE__ . '\ProtectedArticle');
+        $this->index->entityClass(__NAMESPACE__ . '\ProtectedArticle');
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
 
         $this->assertSame($data['title'], $result->title);
@@ -165,7 +165,7 @@ class MarshallerTest extends TestCase
             'user_id' => 1,
         ];
         $called = 0;
-        $this->type->eventManager()->on(
+        $this->index->eventManager()->on(
             'Model.beforeMarshal',
             function ($event, $data, $options) use (&$called) {
                 $called++;
@@ -173,7 +173,7 @@ class MarshallerTest extends TestCase
                 $this->assertInstanceOf('ArrayObject', $options);
             }
         );
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $marshaller->one($data);
 
         $this->assertEquals(1, $called, 'method should be called');
@@ -191,10 +191,10 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $this->type->eventManager()->on('Model.beforeMarshal', function ($event, $data, $options) {
+        $this->index->eventManager()->on('Model.beforeMarshal', function ($event, $data, $options) {
             $data['title'] = 'Mutated';
         });
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
         $this->assertEquals('Mutated', $result->title);
     }
@@ -213,9 +213,9 @@ class MarshallerTest extends TestCase
                 'username' => 'mark',
             ],
         ];
-        $this->type->embedOne('User');
+        $this->index->embedOne('User');
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data, ['associated' => ['User']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -224,7 +224,7 @@ class MarshallerTest extends TestCase
         $this->assertSame($data['body'], $result->body);
         $this->assertSame($data['user']['username'], $result->user->username);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -250,9 +250,9 @@ class MarshallerTest extends TestCase
                 'bad' => 'data'
             ],
         ];
-        $this->type->embedMany('Comments');
+        $this->index->embedMany('Comments');
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data, ['associated' => ['Comments']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -283,7 +283,7 @@ class MarshallerTest extends TestCase
                 'user_id' => 2,
             ]
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->many($data);
 
         $this->assertCount(2, $result);
@@ -300,12 +300,12 @@ class MarshallerTest extends TestCase
      */
     public function testMerge()
     {
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
         $data = [
             'title' => 'New title',
             'body' => 'Updated',
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($doc, $data);
 
         $this->assertSame($result, $doc, 'Object should be the same.');
@@ -329,11 +329,11 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $this->type->validator()
+        $this->index->validator()
             ->add('title', 'numbery', ['rule' => 'numeric']);
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($doc, $data);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -348,14 +348,14 @@ class MarshallerTest extends TestCase
      */
     public function testMergeFieldList()
     {
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
         $doc->accessible('*', false);
 
         $data = [
             'title' => 'New title',
             'body' => 'Updated',
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($doc, $data, ['fieldList' => ['title']]);
 
         $this->assertSame($result, $doc, 'Object should be the same.');
@@ -378,7 +378,7 @@ class MarshallerTest extends TestCase
             'user_id' => 1,
         ];
         $called = 0;
-        $this->type->eventManager()->on(
+        $this->index->eventManager()->on(
             'Model.beforeMarshal',
             function ($event, $data, $options) use (&$called) {
                 $called++;
@@ -386,7 +386,7 @@ class MarshallerTest extends TestCase
                 $this->assertInstanceOf('ArrayObject', $options);
             }
         );
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $marshaller->merge($doc, $data);
 
@@ -405,10 +405,10 @@ class MarshallerTest extends TestCase
             'body' => 'Elastic text',
             'user_id' => 1,
         ];
-        $this->type->eventManager()->on('Model.beforeMarshal', function ($event, $data, $options) {
+        $this->index->eventManager()->on('Model.beforeMarshal', function ($event, $data, $options) {
             $data['title'] = 'Mutated';
         });
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $result = $marshaller->merge($doc, $data);
         $this->assertEquals('Mutated', $result->title);
@@ -421,7 +421,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeEmbeddedOneExisting()
     {
-        $this->type->embedOne('User');
+        $this->index->embedOne('User');
         $data = [
             'title' => 'Testing',
             'body' => 'Elastic text',
@@ -434,7 +434,7 @@ class MarshallerTest extends TestCase
             'user' => new Document(['username' => 'old'], ['markNew' => false])
         ], ['markNew' => false]);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($entity, $data, ['associated' => ['User']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -453,7 +453,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeEmbeddedOneMissing()
     {
-        $this->type->embedOne('User');
+        $this->index->embedOne('User');
         $data = [
             'title' => 'Testing',
             'body' => 'Elastic text',
@@ -465,7 +465,7 @@ class MarshallerTest extends TestCase
             'title' => 'Old',
         ], ['markNew' => false]);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($entity, $data, ['associated' => ['User']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -492,7 +492,7 @@ class MarshallerTest extends TestCase
                 'bad' => 'data'
             ],
         ];
-        $this->type->embedMany('Comments');
+        $this->index->embedMany('Comments');
 
         $entity = new Document([
             'title' => 'old',
@@ -502,7 +502,7 @@ class MarshallerTest extends TestCase
             ]
         ], ['markNew' => false]);
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($entity, $data, ['associated' => ['Comments']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -536,9 +536,9 @@ class MarshallerTest extends TestCase
             ]
         ], ['markNew' => false]);
 
-        $this->type->embedMany('Comments');
+        $this->index->embedMany('Comments');
 
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->merge($entity, $data, ['associated' => ['Comments']]);
 
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
@@ -569,7 +569,7 @@ class MarshallerTest extends TestCase
                 'title' => 'New second',
             ],
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->mergeMany($entities, $data);
 
         $this->assertCount(2, $result);
@@ -595,7 +595,7 @@ class MarshallerTest extends TestCase
                 'body' => 'Nope',
             ],
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->mergeMany($entities, $data, ['fieldList' => ['title']]);
 
         $this->assertCount(2, $result);
@@ -610,7 +610,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeManySomeNew()
     {
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
         $entities = [$doc];
 
         $data = [
@@ -622,7 +622,7 @@ class MarshallerTest extends TestCase
                 'title' => 'New second',
             ],
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->mergeMany($entities, $data);
 
         $this->assertCount(2, $result);
@@ -643,7 +643,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeManyDropsUnknownEntities()
     {
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
         $entities = [$doc];
 
         $data = [
@@ -655,7 +655,7 @@ class MarshallerTest extends TestCase
                 'title' => 'New third',
             ],
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->mergeMany($entities, $data);
 
         $this->assertCount(2, $result);
@@ -677,7 +677,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeManyBadEntityData()
     {
-        $doc = $this->type->get(1);
+        $doc = $this->index->get(1);
         $entities = ['text', ['herp' => 'derp']];
 
         $data = [
@@ -685,7 +685,7 @@ class MarshallerTest extends TestCase
                 'title' => 'New first',
             ],
         ];
-        $marshaller = new Marshaller($this->type);
+        $marshaller = new Marshaller($this->index);
         $result = $marshaller->mergeMany($entities, $data);
 
         $this->assertCount(1, $result);

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -33,9 +33,9 @@ class QueryTest extends TestCase
      */
     public function testConstruct()
     {
-        $type = new Index();
-        $query = new Query($type);
-        $this->assertSame($type, $query->repository());
+        $index = new Index();
+        $query = new Query($index);
+        $this->assertSame($index, $query->repository());
     }
 
     /**
@@ -45,8 +45,8 @@ class QueryTest extends TestCase
      */
     public function testChainedFinders()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
 
         $finder = $query->find()->find();
         $this->assertInstanceOf(\Cake\ElasticSearch\Query::class, $finder);
@@ -57,8 +57,8 @@ class QueryTest extends TestCase
      */
     public function testSetFullQuery()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
 
         $query
             ->where(['name' => 'test'])
@@ -80,8 +80,8 @@ class QueryTest extends TestCase
      */
     public function testSelect()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->select(['a', 'b']));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertEquals(['a', 'b'], $elasticQuery['_source']);
@@ -102,8 +102,8 @@ class QueryTest extends TestCase
      */
     public function testLimit()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->limit(10));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(10, $elasticQuery['size']);
@@ -120,8 +120,8 @@ class QueryTest extends TestCase
      */
     public function testOffset()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->offset(10));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(10, $elasticQuery['from']);
@@ -138,8 +138,8 @@ class QueryTest extends TestCase
      */
     public function testPage()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->page(10));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(225, $elasticQuery['from']);
@@ -164,8 +164,8 @@ class QueryTest extends TestCase
      */
     public function testClause()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
 
         $query->page(10);
         $this->assertSame(25, $query->clause('limit'));
@@ -192,8 +192,8 @@ class QueryTest extends TestCase
      */
     public function testApplyOptions()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
 
         $query->applyOptions([
             'fields' => ['id', 'name'],
@@ -234,8 +234,8 @@ class QueryTest extends TestCase
      */
     public function testOrder()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->order('price'));
 
         $elasticQuery = $query->compileQuery()->toArray();
@@ -286,8 +286,8 @@ class QueryTest extends TestCase
      */
     public function testWhere()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $query->where([
             'name.first' => 'jose',
             'age >' => 29,
@@ -349,8 +349,8 @@ class QueryTest extends TestCase
      */
     public function testQueryMust()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $query->queryMust([
             'name.first' => 'jose',
             'age >' => 29,
@@ -407,8 +407,8 @@ class QueryTest extends TestCase
 
     public function testQueryShould()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $query->queryShould([
             'name.first' => 'jose',
             'age >' => 29,
@@ -470,8 +470,8 @@ class QueryTest extends TestCase
      */
     public function testPostFilter()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $query->postFilter([
             'name.first' => 'jose',
             'age >' => 29,
@@ -533,8 +533,8 @@ class QueryTest extends TestCase
      */
     public function testLimitZero()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->limit(0));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(0, $elasticQuery['size']);
@@ -547,8 +547,8 @@ class QueryTest extends TestCase
      */
     public function testOffsetZero()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->offset(0));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(0, $elasticQuery['from']);
@@ -561,8 +561,8 @@ class QueryTest extends TestCase
      */
     public function testHighlight()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $query->highlight([
             'pre_tags' => [''],
             'post_tags' => [''],
@@ -588,8 +588,8 @@ class QueryTest extends TestCase
      */
     public function testMinScore()
     {
-        $type = new Index();
-        $query = new Query($type);
+        $index = new Index();
+        $query = new Query($index);
         $this->assertSame($query, $query->withMinScore(1));
         $elasticQuery = $query->compileQuery()->toArray();
         $this->assertSame(1, $elasticQuery['min_score']);

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -238,7 +238,7 @@ class DocumentContextTest extends TestCase
     {
         $context = new DocumentContext($this->request, [
             'entity' => $collection,
-            'type' => 'articles',
+            'index' => 'articles',
         ]);
 
         $result = $context->val('0.title');
@@ -269,7 +269,7 @@ class DocumentContextTest extends TestCase
 
         $context = new DocumentContext($this->request, [
             'entity' => $entity,
-            'type' => $articles,
+            'index' => $articles,
         ]);
         $this->assertTrue($context->isRequired('title'));
         $this->assertFalse($context->isRequired('body'));
@@ -288,7 +288,7 @@ class DocumentContextTest extends TestCase
 
         $context = new DocumentContext($this->request, [
             'entity' => $entity,
-            'type' => $articles,
+            'index' => $articles,
             'validator' => 'alternate'
         ]);
         $this->assertFalse($context->isRequired('title'));
@@ -342,7 +342,7 @@ class DocumentContextTest extends TestCase
 
         $context = new DocumentContext($this->request, [
             'entity' => $row,
-            'type' => $articles,
+            'index' => $articles,
         ]);
 
         $this->assertEquals([], $context->error('title'));
@@ -399,7 +399,7 @@ class DocumentContextTest extends TestCase
         $articles = $this->setupIndex();
         $context = new DocumentContext($this->request, [
             'entity' => new Document([]),
-            'type' => 'articles',
+            'index' => 'articles',
         ]);
         $result = $context->fieldNames();
         $this->assertContains('title', $result);
@@ -422,7 +422,7 @@ class DocumentContextTest extends TestCase
         ]);
         $context = new DocumentContext($this->request, [
             'entity' => $row,
-            'type' => $articles,
+            'index' => $articles,
         ]);
 
         $this->assertEquals($this->textField, $context->type('title'));
@@ -446,7 +446,7 @@ class DocumentContextTest extends TestCase
         $row = new Document([]);
         $context = new DocumentContext($this->request, [
             'entity' => $row,
-            'type' => $profiles,
+            'index' => $profiles,
         ]);
 
         $this->assertEquals($this->textField, $context->type('username'));


### PR DESCRIPTION
Reviewing the latest changes, I found some flaws.

Plus the fixes, I updated how mapping type is derived from Index name, when not explicitly defined.
I think that way should be more clear the differences between 'Index' and (mapping) 'Type' names.