### PR TITLE
add match function to the QueryBuilder

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -531,6 +531,25 @@ class QueryBuilder
     }
 
     /**
+     * Returns a Match query object that query documents that have fields containing a match.
+     *
+     * ### Example:
+     *
+     * {{{
+     *  $builder->match('user.name', 'jose');
+     * }}}
+     *
+     * @param string $field The field to query by.
+     * @param string $value The match to find in field.
+     * @return \Elastica\Query\Match
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+     */
+    public function match($field, $value)
+    {
+        return new Elastica\Query\Match($field, $value);
+    }
+    
+    /**
      * Returns a Term query object that query documents that have fields containing a term.
      *
      * ### Example:


### PR DESCRIPTION
Hi guys,

I noticed that the match function is missing in QueryBuilder. Is it missing for a special reason?

Thanks.