### PR TITLE
Fix resolving of document entities and registry alias

### DIFF
--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -150,7 +150,7 @@ class Connection extends Client implements ConnectionInterface
      *
      * @param object $instance logger object instance
      * @return object logger instance
-     * @deprecated 2.0 Will be replaced by setLogger()
+     * @deprecated 2.0 Will be replaced by getLogger()/setLogger()
      */
     public function logger($instance = null)
     {

--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -154,22 +154,31 @@ class Connection extends Client implements ConnectionInterface
      */
     public function logger($instance = null)
     {
-        $this->setLogger($instance);
-    }
-
-    /**
-     * Sets the logger object instance. When called with no arguments
-     * it returns the currently setup logger instance.
-     *
-     * @param object $instance logger object instance
-     * @return object logger instance
-     */
-    public function setLogger($instance = null)
-    {
         if ($instance === null) {
             return $this->_logger;
         }
         $this->_logger = $instance;
+    }
+
+    /**
+     * Sets the logger object instance.
+     *
+     * @param object $instance logger object instance
+     * @return void
+     */
+    public function setLogger($instance)
+    {
+        $this->_logger = $instance;
+    }
+
+    /**
+     * Get the logger object instance.
+     *
+     * @return object logger instance
+     */
+    public function getLogger()
+    {
+        return $this->_logger;
     }
 
     /**

--- a/src/Datasource/Connection.php
+++ b/src/Datasource/Connection.php
@@ -150,8 +150,21 @@ class Connection extends Client implements ConnectionInterface
      *
      * @param object $instance logger object instance
      * @return object logger instance
+     * @deprecated 2.0 Will be replaced by setLogger()
      */
     public function logger($instance = null)
+    {
+        $this->setLogger($instance);
+    }
+
+    /**
+     * Sets the logger object instance. When called with no arguments
+     * it returns the currently setup logger instance.
+     *
+     * @param object $instance logger object instance
+     * @return object logger instance
+     */
+    public function setLogger($instance = null)
     {
         if ($instance === null) {
             return $this->_logger;

--- a/src/Index.php
+++ b/src/Index.php
@@ -89,6 +89,13 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected $_type;
 
     /**
+     * Registry key used to create this index object
+     *
+     * @var string
+     */
+    protected $_registryAlias;
+
+    /**
      * The name of the class that represent a single document for this type
      *
      * @var string
@@ -125,6 +132,9 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function __construct(array $config = [])
     {
+        if (!empty($config['registryAlias'])) {
+            $this->setRegistryAlias($config['registryAlias']);
+        }
         if (!empty($config['connection'])) {
             $this->setConnection($config['connection']);
         }
@@ -253,6 +263,33 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         return $this->getConnection();
+    }
+
+    /**
+     * Sets the index registry key used to create this table instance.
+     *
+     * @param string $registryAlias The key used to access this object.
+     * @return $this
+     */
+    public function setRegistryAlias($registryAlias)
+    {
+        $this->_registryAlias = $registryAlias;
+
+        return $this;
+    }
+
+    /**
+     * Returns the index registry key used to create this table instance.
+     *
+     * @return string
+     */
+    public function getRegistryAlias()
+    {
+        if ($this->_registryAlias === null) {
+            $this->_registryAlias = $this->getAlias();
+        }
+
+        return $this->_registryAlias;
     }
 
     /**
@@ -460,7 +497,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             'markNew' => false,
             'markClean' => true,
             'useSetters' => false,
-            'source' => $this->getName(),
+            'source' => $this->getRegistryAlias(),
         ];
         $data = $result->getData();
         $data['id'] = $result->getId();
@@ -613,7 +650,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             $entities[$key]->id = $doc->getId();
             $entities[$key]->_version = $doc->getVersion();
             $entities[$key]->isNew(false);
-            $entities[$key]->source($this->getName());
+            $entities[$key]->source($this->getRegistryAlias());
             $entities[$key]->clean();
 
             $this->dispatchEvent('Model.afterSave', [
@@ -677,7 +714,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         $entity->id = $doc->getId();
         $entity->_version = $doc->getVersion();
         $entity->isNew(false);
-        $entity->source($this->getName());
+        $entity->source($this->getRegistryAlias());
         $entity->clean();
 
         $this->dispatchEvent('Model.afterSave', [
@@ -760,7 +797,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($data === null) {
             $class = $this->entityClass();
 
-            return new $class([], ['source' => $this->getName()]);
+            return new $class([], ['source' => $this->getRegistryAlias()]);
         }
 
         return $this->marshaller()->one($data, $options);

--- a/src/Index.php
+++ b/src/Index.php
@@ -806,7 +806,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return $this->_documentClass = $default;
             }
 
-            $alias = Inflector::singularize(substr(array_pop($parts), 0, -4));
+            $alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
             $name = implode('\\', array_slice($parts, 0, -1)) . '\Document\\' . $alias;
             if (!class_exists($name)) {
                 return $this->_documentClass = $default;

--- a/src/IndexRegistry.php
+++ b/src/IndexRegistry.php
@@ -88,6 +88,7 @@ class IndexRegistry
             $connectionName = $options['className']::defaultConnectionName();
             $options['connection'] = ConnectionManager::get($connectionName);
         }
+        $options['registryAlias'] = $alias;
         static::$instances[$alias] = new $options['className']($options);
 
         return static::$instances[$alias];

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -70,7 +70,7 @@ class ResultSet extends IteratorIterator implements Countable, JsonSerializable
             $this->embeds[$embed->property()] = $embed;
         }
         $this->entityClass = $repo->entityClass();
-        $this->repoName = $repo->getName();
+        $this->repoName = $repo->getRegistryAlias();
         parent::__construct($resultSet);
     }
 

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -672,6 +672,19 @@ class IndexTest extends TestCase
     }
 
     /**
+     * Test the alias method.
+     *
+     * @return void
+     */
+    public function testRegistryAlias()
+    {
+        $index = IndexRegistry::get('TestPlugin.Comments');
+
+        $this->assertEquals('articles', $this->index->getRegistryAlias());
+        $this->assertEquals('TestPlugin.Comments', $index->getRegistryAlias());
+    }
+
+    /**
      * Test hasField()
      *
      * @return void

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -17,6 +17,7 @@ namespace Cake\ElasticSearch\Test;
 use Cake\Datasource\ConnectionManager;
 use Cake\ElasticSearch\Document;
 use Cake\ElasticSearch\Index;
+use Cake\ElasticSearch\IndexRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -78,6 +79,18 @@ class IndexTest extends TestCase
     public function testEntityClassDefault()
     {
         $this->assertEquals('\Cake\ElasticSearch\Document', $this->index->entityClass());
+    }
+
+    /**
+     * Test a custom entityClass.
+     *
+     * @return void
+     */
+    public function testEntityClassCustom()
+    {
+        $index = IndexRegistry::get('TestPlugin.Comments');
+
+        $this->assertEquals('TestPlugin\Model\Document\Comment', $index->entityClass());
     }
 
     /**

--- a/tests/testapp/Plugin/TestPlugin/src/Model/Document/Comment.php
+++ b/tests/testapp/Plugin/TestPlugin/src/Model/Document/Comment.php
@@ -1,0 +1,8 @@
+<?php
+namespace TestPlugin\Model\Document;
+
+use Cake\ElasticSearch\Document;
+
+class Comment extends Document
+{
+}


### PR DESCRIPTION
This PR fixes 3 issues:

### Fix resolving of Document entities
Using your own document entity was currently not possible in the case where the entity was not manually defined in the index (using entityClass). 

For instance, when using index 'ArticlesIndex' the entityClass function would resolve the document name to 'Articles**I**' instead of just Articles (notice the letter I) and then singularize it resulting in always faling back to the default Document class. Weird that this small bug wasn't noticed before?

### Added registry alias on the Index class
There was no proper implementation of a registry alias resulting in document context's to not work properly when using plugin indexes for example. 

Document's created in the Index are passed the alias as source instead of the registryAlias which breaks document context in plugin cases because the entity could not resulve to the index class. We could work around this by passing the 'type' param to the context settings in FormHelper but thats a bit meh ?

### Added setLogger()/getLogger() to Connection and deprecate logger() 
Plugins like debug_kit already use the setLogger method in the SqlLogPanel, Elastica\Client has its own setLogger method that conflicts and throws an exception because it only accepts in instance of Psr\Log\LoggerInterface, overriding this method makes everything play nice and is more in line with cake 3.6

Wrote some tests for the first two, can someone validate if these are sufficient ?
