### PR TITLE
Add IsUique rule, Add 'refresh'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - phpenv rehash
 
 before_install:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.deb && sudo dpkg -i --force-confnew elasticsearch-6.2.2.deb && sudo service elasticsearch restart
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.deb && sudo dpkg -i --force-confnew elasticsearch-6.2.4.deb && sudo service elasticsearch restart
 
 install:
   - composer self-update

--- a/src/Index.php
+++ b/src/Index.php
@@ -637,7 +637,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function saveMany($entities, $options = [])
     {
-        $options += ['checkRules' => true];
+        $options += [
+            'checkRules' => true,
+            'refresh' => false
+        ];
         $options = new ArrayObject($options);
 
         $documents = [];
@@ -679,6 +682,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $type->addDocuments($documents);
 
+        if ($options['refresh']) {
+            $type->getIndex()->refresh();
+        }
+
         foreach ($documents as $key => $document) {
             $entities[$key]->id = $doc->getId();
             $entities[$key]->_version = $doc->getVersion();
@@ -712,7 +719,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function save(EntityInterface $entity, $options = [])
     {
-        $options += ['checkRules' => true];
+        $options += [
+            'checkRules' => true,
+            'refresh' => false
+        ];
         $options = new ArrayObject($options);
         $event = $this->dispatchEvent('Model.beforeSave', [
             'entity' => $entity,
@@ -743,6 +753,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
         $doc->setAutoPopulate(true);
 
         $type->addDocument($doc);
+
+        if ($options['refresh']) {
+            $type->getIndex()->refresh();
+        }
 
         $entity->id = $doc->getId();
         $entity->_version = $doc->getVersion();
@@ -776,7 +790,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             $msg = 'Deleting requires an "id" value.';
             throw new InvalidArgumentException($msg);
         }
-        $options += ['checkRules' => true];
+        $options += [
+            'checkRules' => true,
+            'refresh' => false
+        ];
         $options = new ArrayObject($options);
         $event = $this->dispatchEvent('Model.beforeDelete', [
             'entity' => $entity,
@@ -798,6 +815,10 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $type = $this->getConnection()->getIndex($this->getName())->getType($this->getType());
         $result = $type->deleteDocument($doc);
+
+        if ($options['refresh']) {
+            $type->getIndex()->refresh();
+        }
 
         $this->dispatchEvent('Model.afterDelete', [
             'entity' => $entity,

--- a/src/Rule/IsUnique.php
+++ b/src/Rule/IsUnique.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Rule;
+
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Checks that a list of fields from an entity are unique in the table
+ */
+class IsUnique
+{
+
+    /**
+     * The list of fields to check
+     *
+     * @var array
+     */
+    protected $_fields;
+
+    /**
+     * The options to use.
+     *
+     * @var array
+     */
+    protected $_options;
+
+    /**
+     * Constructor.
+     *
+     * @param array $fields The list of fields to check uniqueness for
+     */
+    public function __construct(array $fields)
+    {
+        $this->_fields = $fields;
+    }
+
+    /**
+     * Performs the uniqueness check
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity from where to extract the fields
+     *   where the `repository` key is required.
+     * @param array $options Options passed to the check,
+     * @return bool
+     */
+    public function __invoke(EntityInterface $entity, array $options)
+    {
+        if (!$entity->extract($this->_fields, true)) {
+            return true;
+        }
+
+        $conditions = $entity->extract($this->_fields);
+
+        if ($entity->isNew() === false) {
+            $conditions['_id not in'] = [ $entity->get('id') ];
+        }
+
+        return !$options['repository']->exists($conditions);
+    }
+}

--- a/src/Rule/IsUnique.php
+++ b/src/Rule/IsUnique.php
@@ -15,6 +15,7 @@
 namespace Cake\ElasticSearch\Rule;
 
 use Cake\Datasource\EntityInterface;
+use Cake\ElasticSearch\QueryBuilder;
 
 /**
  * Checks that a list of fields from an entity are unique in the table
@@ -30,14 +31,12 @@ class IsUnique
     protected $_fields;
 
     /**
-     * The options to use.
-     *
-     * @var array
-     */
-    protected $_options;
-
-    /**
      * Constructor.
+     *
+     * ### Options
+     *
+     * - `filterNullFields` Set to false to allow keys with null values in the
+     *   the conditions array.
      *
      * @param array $fields The list of fields to check uniqueness for
      */
@@ -51,6 +50,7 @@ class IsUnique
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity from where to extract the fields
      *   where the `repository` key is required.
+     *
      * @param array $options Options passed to the check,
      * @return bool
      */
@@ -60,10 +60,15 @@ class IsUnique
             return true;
         }
 
-        $conditions = $entity->extract($this->_fields);
+        $fields = $entity->extract($this->_fields);
+        $conditions = [];
+
+        foreach ($fields as $field => $value) {
+            $conditions[$field . ' is'] = $value;
+        }
 
         if ($entity->isNew() === false) {
-            $conditions['_id not in'] = [ $entity->get('id') ];
+            $conditions['_id is not'] = $entity->get('id');
         }
 
         return !$options['repository']->exists($conditions);

--- a/src/Rule/IsUnique.php
+++ b/src/Rule/IsUnique.php
@@ -15,7 +15,6 @@
 namespace Cake\ElasticSearch\Rule;
 
 use Cake\Datasource\EntityInterface;
-use Cake\ElasticSearch\QueryBuilder;
 
 /**
  * Checks that a list of fields from an entity are unique in the table

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -321,6 +321,29 @@ class IndexTest extends TestCase
     }
 
     /**
+     * Test saving documents with index refresh
+     *
+     * @return void
+     */
+    public function testSaveWithRefresh()
+    {
+        $doc = new Document([
+            'title' => 'A brand new article',
+            'body' => 'Some new content'
+        ], ['markNew' => true]);
+
+        $document = $this->index->save($doc, [
+            'refresh' => true
+        ]);
+
+        $query = $this->index->find();
+        $match = $query->firstMatch([ 'id' => $document->id ]);
+
+        $this->assertCount(3, $query);
+        $this->assertInstanceOf('Cake\ElasticSearch\Document', $match);
+    }
+
+    /**
      * Test save triggers events.
      *
      * @return void

--- a/tests/TestCase/QueryBuilderTest.php
+++ b/tests/TestCase/QueryBuilderTest.php
@@ -510,7 +510,7 @@ class QueryBuilderTest extends TestCase
         $builder = new QueryBuilder;
         $result = $builder->script("doc['foo'] > 2");
         $expected = [
-            'script' => ['script' => ['inline' => "doc['foo'] > 2"]]
+            'script' => ['script' => ['source' => "doc['foo'] > 2"]]
         ];
         $this->assertEquals($expected, $result->toArray());
     }

--- a/tests/TestCase/RulesCheckerTest.php
+++ b/tests/TestCase/RulesCheckerTest.php
@@ -53,12 +53,25 @@ class RulesCheckerTest extends TestCase
     {
         $document = $this->index->get(1);
         $rules = $this->index->rulesChecker();
-        $rules->add(new IsUnique([ 'user_id' ]), '_isUnique', [
-            'errorField' => 'user_id',
-            'message' => 'This value is already in use'
-        ]);
+        $rules->add(new IsUnique([ 'user_id' ]));
 
         $document->setDirty('user_id', true);
+        $this->assertInstanceOf('\Cake\ElasticSearch\Document', $this->index->save($document));
+    }
+
+    /**
+     * Test unique rule on existing document
+     *
+     * @group save
+     * @return void
+     */
+    public function testIsUniqueWithNullValue()
+    {
+        $document = $this->index->get(1);
+        $rules = $this->index->rulesChecker();
+        $rules->add(new IsUnique([ 'user_id', 'title' ]));
+
+        $document->title = null;
         $this->assertInstanceOf('\Cake\ElasticSearch\Document', $this->index->save($document));
     }
 }

--- a/tests/TestCase/RulesCheckerTest.php
+++ b/tests/TestCase/RulesCheckerTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Cake\ElasticSearch\Test\TestCase;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ElasticSearch\Document;
+use Cake\ElasticSearch\Index;
+use Cake\ElasticSearch\Rule\IsUnique;
+use Cake\TestSuite\TestCase;
+
+class RulesCheckerTest extends TestCase
+{
+    public $fixtures = ['plugin.cake/elastic_search.articles'];
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+        $this->index = new Index([
+            'name' => 'articles',
+            'connection' => $this->connection
+        ]);
+    }
+
+    /**
+     * Tests the isUnique domain rule
+     *
+     * @group save
+     * @return void
+     */
+    public function testIsUniqueDomainRule()
+    {
+        $document = new Document([
+            'user_id' => 1
+        ]);
+
+        $rules = $this->index->rulesChecker();
+        $rules->add(new IsUnique([ 'user_id' ]), '_isUnique', [
+            'errorField' => 'user_id',
+            'message' => 'This value is already in use'
+        ]);
+
+        $this->assertFalse($this->index->save($document));
+        $this->assertEquals(['_isUnique' => 'This value is already in use'], $document->getError('user_id'));
+    }
+
+    /**
+     * Test unique rule on existing document
+     *
+     * @group save
+     * @return void
+     */
+    public function testIsUniqueExisting()
+    {
+        $document = $this->index->get(1);
+        $rules = $this->index->rulesChecker();
+        $rules->add(new IsUnique([ 'user_id' ]), '_isUnique', [
+            'errorField' => 'user_id',
+            'message' => 'This value is already in use'
+        ]);
+
+        $document->setDirty('user_id', true);
+        $this->assertInstanceOf('\Cake\ElasticSearch\Document', $this->index->save($document));
+    }
+}


### PR DESCRIPTION
- Added an IsUnique rule
- Add 'refresh' option on save/delete operations
- Fix tests for [Elastica 6.0.2](https://github.com/ruflin/Elastica/blob/master/CHANGELOG.md) - Use ``source`` script field instead of deprecated (since ES 5.6) ``inline``
- Update ElasticSearch version in tests to 6.2.4