### PR TITLE
Add support for nested validator errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,13 @@
             "TestPlugin\\": "tests/testapp/Plugin/TestPlugin/src",
             "TestPluginTwo\\": "tests/testapp/Plugin/TestPluginTwo/src"
         }
+    },
+    "scripts": {
+        "check": [
+            "@test",
+            "@cs-check"
+        ],
+        "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "test": "phpunit --colors=always"
     }
 }

--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -18,6 +18,7 @@ use Cake\Collection\Collection;
 use Cake\ElasticSearch\Document;
 use Cake\ElasticSearch\IndexRegistry;
 use Cake\Http\ServerRequest;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Cake\View\Form\ContextInterface;
 use RuntimeException;
@@ -343,11 +344,16 @@ class DocumentContext implements ContextInterface
     {
         $parts = explode('.', $field);
         $entity = $this->entity($parts);
+        $errors = [];
 
         if ($entity instanceof Document) {
-            return $entity->getError(array_pop($parts));
+            $errors = $entity->getError(array_pop($parts));
+
+            if (!$errors && $this->_context['entity'] instanceof Document) {
+                $errors = array_values((array)Hash::get($this->_context['entity']->getErrors(), $field, []));
+            }
         }
 
-        return [];
+        return $errors;
     }
 }

--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -350,7 +350,7 @@ class DocumentContext implements ContextInterface
             $errors = $entity->getError(array_pop($parts));
 
             if (!$errors && $this->_context['entity'] instanceof Document) {
-                $errors = array_values((array)Hash::get($this->_context['entity']->getErrors(), $field, []));
+                $errors = Hash::extract($this->_context['entity']->getErrors(), $field) ?: [];
             }
         }
 

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -306,7 +306,7 @@ class DocumentContextTest extends TestCase
     {
         $context = new DocumentContext($this->request, [
             'entity' => $collection,
-            'tyupe' => 'articles',
+            'type' => 'articles',
         ]);
 
         $this->assertTrue($context->hasError('0.title'));
@@ -332,7 +332,7 @@ class DocumentContextTest extends TestCase
 
         $row = new Article([
             'title' => 'My title',
-            'user' => new Document(['username' => 'Mark']),
+            'user' => new Document(['username' => 'Mark'])
         ]);
         $row->setError('title', []);
         $row->setError('body', 'Gotta have one');
@@ -351,6 +351,38 @@ class DocumentContextTest extends TestCase
         $this->assertEquals($expected, $context->error('body'));
 
         $expected = ['Required'];
+        $this->assertEquals($expected, $context->error('user.username'));
+    }
+
+    /**
+     * Test validation errors coming from a nested validator
+     *
+     * @return void
+     */
+    public function testNestedValidatorErrors()
+    {
+        $articles = $this->setupIndex();
+
+        $row = new Article([
+            'title' => 'My title',
+            'user' => new Document(['username' => 'Mark'])
+        ]);
+
+        $row->setErrors([
+            'user' => [
+                'username' => [ 'Required' ]
+            ]
+        ]);
+
+        $context = new DocumentContext($this->request, [
+            'entity' => $row,
+            'index' => $articles,
+        ]);
+
+        $expected = [ 'username' => [ 'Required' ] ];
+        $this->assertEquals($expected, $context->error('user'));
+
+        $expected = [ 'Required' ];
         $this->assertEquals($expected, $context->error('user.username'));
     }
 

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -365,12 +365,19 @@ class DocumentContextTest extends TestCase
 
         $row = new Article([
             'title' => 'My title',
-            'user' => new Document(['username' => 'Mark'])
+            'user' => new Document(['username' => 'Mark']),
+            'comments' => [
+                new Document(['comment' => '']),
+                new Document(['comment' => 'Second comment']),
+            ]
         ]);
 
         $row->setErrors([
             'user' => [
                 'username' => [ 'Required' ]
+            ],
+            'comments' => [
+                0 => [ 'comment' => [ 'Required' ] ]
             ]
         ]);
 
@@ -384,6 +391,10 @@ class DocumentContextTest extends TestCase
 
         $expected = [ 'Required' ];
         $this->assertEquals($expected, $context->error('user.username'));
+
+        $expected = [ 'Required' ];
+        $this->assertEquals([], $context->error('comments.0'));
+        $this->assertEquals($expected, $context->error('comments.0.comment'));
     }
 
     /**


### PR DESCRIPTION
This PR makes DocumentContext work correctly when using validation errors coming from a nested Validator setup. Also changed Document requirement to EntityInterface 