### PR TITLE
Support nested validation errors on nonexistent entities

### DIFF
--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -344,14 +344,19 @@ class DocumentContext implements ContextInterface
     {
         $parts = explode('.', $field);
         $entity = $this->entity($parts);
+        $entityErrors = [];
         $errors = [];
+
+        if ($this->_context['entity'] instanceof Document) {
+            $entityErrors = $this->_context['entity']->getErrors();
+        }
 
         if ($entity instanceof Document) {
             $errors = $entity->getError(array_pop($parts));
+        }
 
-            if (!$errors && $this->_context['entity'] instanceof Document) {
-                $errors = Hash::extract($this->_context['entity']->getErrors(), $field) ?: [];
-            }
+        if (!$errors && $entityErrors && !is_array($entity)) {
+            $errors = Hash::extract($entityErrors, $field) ?: [];
         }
 
         return $errors;

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -369,7 +369,7 @@ class DocumentContextTest extends TestCase
             'comments' => [
                 new Document(['comment' => '']),
                 new Document(['comment' => 'Second comment']),
-                new Document(['comment' => 'Third comment']),
+                new Document(['comment' => 'Third comment'])
             ]
         ]);
 
@@ -379,7 +379,8 @@ class DocumentContextTest extends TestCase
             ],
             'comments' => [
                 0 => [ 'comment' => [ 'Required' ] ],
-                2 => [ 'comment' => [ 'Required' ] ]
+                2 => [ 'comment' => [ 'Required' ] ],
+                3 => [ 'comment' => [ 'Required' ] ]
             ]
         ]);
 
@@ -398,6 +399,7 @@ class DocumentContextTest extends TestCase
         $this->assertEquals([], $context->error('comments.0'));
         $this->assertEquals($expected, $context->error('comments.0.comment'));
         $this->assertEquals($expected, $context->error('comments.2.comment'));
+        $this->assertEquals($expected, $context->error('comments.3.comment'));
     }
 
     /**

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -369,6 +369,7 @@ class DocumentContextTest extends TestCase
             'comments' => [
                 new Document(['comment' => '']),
                 new Document(['comment' => 'Second comment']),
+                new Document(['comment' => 'Third comment']),
             ]
         ]);
 
@@ -377,7 +378,8 @@ class DocumentContextTest extends TestCase
                 'username' => [ 'Required' ]
             ],
             'comments' => [
-                0 => [ 'comment' => [ 'Required' ] ]
+                0 => [ 'comment' => [ 'Required' ] ],
+                2 => [ 'comment' => [ 'Required' ] ]
             ]
         ]);
 
@@ -395,6 +397,7 @@ class DocumentContextTest extends TestCase
         $expected = [ 'Required' ];
         $this->assertEquals([], $context->error('comments.0'));
         $this->assertEquals($expected, $context->error('comments.0.comment'));
+        $this->assertEquals($expected, $context->error('comments.2.comment'));
     }
 
     /**


### PR DESCRIPTION
Tests will fail because of an issue in Cake core that needs to be resolved first so **do not merge** this one just yet. 

Refs https://github.com/cakephp/cakephp/pull/12250