### PR TITLE
Allow for associated element to be keys when marshalling

### DIFF
--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -79,7 +79,8 @@ class Marshaller
 
         foreach ($this->index->embedded() as $embed) {
             $property = $embed->property();
-            if (in_array($embed->getAlias(), $options['associated']) &&
+            $alias = $embed->getAlias();
+            if ((in_array($alias, $options['associated']) || isset($options['associated'][$alias])) &&
                 isset($data[$property])
             ) {
                 $data[$property] = $this->newNested($embed, $data[$property]);


### PR DESCRIPTION
This allows for the following options array when marshalling

```php
$index = IndexRegistry::get('User');

$options = [
    'associated' => [
        'UserType' => ['accessibleFields' => ['thisField' => true]],
        'AccessToken' => ['accessibleFields' => ['thatField' => true]],
    ]
];
$index->newEntity($data, $options);
```

