### PR TITLE
Fixes/honour hydration options of embeds

### DIFF
--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -2,6 +2,7 @@
 namespace Cake\ElasticSearch\Association;
 
 use Cake\Core\App;
+use Cake\ElasticSearch\Index;
 use Cake\Utility\Inflector;
 
 /**
@@ -47,6 +48,13 @@ abstract class Embedded
     protected $property;
 
     /**
+     * The index class this embed is linked to
+     *
+     * @var string
+     */
+    protected $indexClass;
+
+    /**
      * Constructor
      *
      * @param string $alias The alias/name for the embedded document.
@@ -57,7 +65,8 @@ abstract class Embedded
         $this->alias = $alias;
         $properties = [
             'entityClass',
-            'property'
+            'property',
+            'indexClass'
         ];
         $options += [
             'entityClass' => $alias
@@ -117,6 +126,38 @@ abstract class Embedded
         }
 
         return $this->entityClass;
+    }
+
+    /**
+     * Get/set the index class used for this embed.
+     *
+     * @param string|null|Index $name The class name to set.
+     *
+     * @return string The class name.
+     */
+    public function indexClass($name = null)
+    {
+        if ($name === null && !$this->indexClass) {
+            $alias = Inflector::pluralize($this->alias);
+            $class = App::className($alias . 'Index', 'Model/Index');
+
+            if ($class) {
+                return $this->indexClass = $class;
+            } else {
+                return $this->indexClass = '\Cake\ElasticSearch\Index';
+            }
+        }
+
+        if ($name !== null) {
+            if ($name instanceof Index) {
+                $this->indexClass = get_class($name);
+            } elseif (is_string($name)) {
+                $class = App::className($name, 'Model/Index');
+                $this->indexClass = $class;
+            }
+        }
+
+        return $this->indexClass;
     }
 
     /**

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -79,7 +79,8 @@ class Marshaller
 
         foreach ($this->index->embedded() as $embed) {
             $property = $embed->property();
-            if (in_array($embed->getAlias(), $options['associated']) &&
+            $alias = $embed->getAlias();
+            if ((in_array($alias, $options['associated']) || isset($options['associated'][$alias])) &&
                 isset($data[$property])
             ) {
                 $data[$property] = $this->newNested($embed, $data[$property]);

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -46,7 +46,9 @@ class EmbeddedDocumentTest extends TestCase
         $this->assertNull($this->index->embedOne('Address'));
         $assocs = $this->index->embedded();
         $this->assertCount(1, $assocs);
+        $this->assertInstanceOf('Cake\ElasticSearch\Association\EmbedOne', $assocs[0]);
         $this->assertEquals('\Cake\ElasticSearch\Document', $assocs[0]->entityClass());
+        $this->assertEquals('\Cake\ElasticSearch\Index', $assocs[0]->indexClass());
         $this->assertEquals('address', $assocs[0]->property());
     }
 
@@ -113,6 +115,22 @@ class EmbeddedDocumentTest extends TestCase
         $result = $this->index->find()->where(['username' => 'mark']);
         $rows = $result->toArray();
         $this->assertCount(1, $rows);
+    }
+
+    /**
+     * Test defining many embedded documents.
+     *
+     * @return void
+     */
+    public function testEmbedMany()
+    {
+        $this->assertNull($this->index->embedMany('Address'));
+        $assocs = $this->index->embedded();
+        $this->assertCount(1, $assocs);
+        $this->assertInstanceOf('Cake\ElasticSearch\Association\EmbedMany', $assocs[0]);
+        $this->assertEquals('\Cake\ElasticSearch\Document', $assocs[0]->entityClass());
+        $this->assertEquals('\Cake\ElasticSearch\Index', $assocs[0]->indexClass());
+        $this->assertEquals('address', $assocs[0]->property());
     }
 
     /**

--- a/tests/testapp/TestApp/src/Model/Document/User.php
+++ b/tests/testapp/TestApp/src/Model/Document/User.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TestApp\Model\Document;
+
+use Cake\ElasticSearch\Document;
+
+class User extends Document
+{
+}

--- a/tests/testapp/TestApp/src/Model/Index/AccountsIndex.php
+++ b/tests/testapp/TestApp/src/Model/Index/AccountsIndex.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TestApp\Model\Index;
+
+use Cake\ElasticSearch\Index;
+
+class AccountsIndex extends Index
+{
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->embedMany('User', ['property' => 'users']);
+    }
+
+    public function getName()
+    {
+        return 'accounts';
+    }
+
+    public function getType()
+    {
+        return 'accounts';
+    }
+}

--- a/tests/testapp/TestApp/src/Model/Index/UsersIndex.php
+++ b/tests/testapp/TestApp/src/Model/Index/UsersIndex.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TestApp\Model\Index;
+
+use Cake\ElasticSearch\Index;
+
+class UsersIndex extends Index
+{
+
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->embedOne('UserType');
+    }
+
+    public function getName()
+    {
+        return 'users';
+    }
+
+    public function getType()
+    {
+        return 'users';
+    }
+}


### PR DESCRIPTION
Allows for multi level embedding whilst marshalling via one/many if `associated` is provided. Also supports the `associated` param with options so you can limited the hydration via `accessibleFields`.

For example
```php
        $data = [
            'address' => '123 West Street',
            'remove_this' => 'something',
            'users' => [
                [
                    'first_name' => 'Mark',
                    'last_name' => 'Story',
                    'user_type' => [
                        'label' => 'Admin',
                        'level' => 21
                    ]
                ],
                ['first_name' => 'Clare', 'last_name' => 'Smith'],
            ]
        ];
        $options = [
            'accessibleFields' => ['remove_this' => false],
            'associated' => [
                'User' => [
                    'accessibleFields' => ['last_name' => false],
                    'associated' => [
                        'UserType' => [
                            'accessibleFields' => ['level' => false]
                        ]
                    ]
                ]
            ]
        ];

        $marshaller = new Marshaller($index);
        $result = $marshaller->one($data, $options);
```