### PR TITLE
Fix QueryBuilder with numerically indexed arrays

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -681,7 +681,6 @@ class QueryBuilder
         $result = [];
         foreach ($conditions as $k => $c) {
             $numericKey = is_numeric($k);
-            $operator = strtolower($k);
 
             if ($numericKey) {
                 $c = $this->parse($c);
@@ -691,6 +690,8 @@ class QueryBuilder
                 $result[] = $c;
                 continue;
             }
+
+            $operator = strtolower($k);
 
             if ($operator === 'and') {
                 $result[] = $this->__call('and', $this->parse($c));

--- a/tests/TestCase/QueryBuilderTest.php
+++ b/tests/TestCase/QueryBuilderTest.php
@@ -732,4 +732,35 @@ class QueryBuilderTest extends TestCase
         ];
         $this->assertEquals($expected, $filter);
     }
+
+    /**
+     * Tests the parse() method with numerically indexed arrays
+     *
+     * @return void
+     */
+    public function testParseNumericArray()
+    {
+        $builder = new QueryBuilder();
+        $filter = $builder->parse([
+            $builder->simpleQueryString('name', 'mark'),
+            ['age >' => 29],
+            'not' => [
+                ['name' => 'jose'],
+                ['age >' => 35],
+            ],
+        ]);
+        $expected = [
+            $builder->simpleQueryString('name', 'mark'),
+            $builder->and(
+                $builder->gt('age', 29)
+            ),
+            $builder->not(
+                $builder->and(
+                    $builder->and($builder->term('name', 'jose')),
+                    $builder->and($builder->gt('age', 35))
+                )
+            ),
+        ];
+        $this->assertEquals($expected, $filter);
+    }
 }


### PR DESCRIPTION
Queries with numerically indexed conditions currently fail in 3.0 due to strict typing (see attached test).
```
TypeError: strtolower() expects parameter 1 to be string, int given
/www-root/vendor/cakephp/elastic-search/src/QueryBuilder.php:683
```

This breaks use cases where we want to directly use QueryExpression classes without operators and prevents us from upgrading to Cake 4. Simply moving the `strtolower` to after handling the numeric case fixes the issue.