### PR TITLE
Allow use Elastica 7.x with CakePHP 3.6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/elastic-search"
     },
     "require": {
-        "ruflin/elastica": "^6.0"
+        "ruflin/elastica": "^6.0|^7.0"
     },
     "require-dev": {
         "cakephp/cakephp": "^3.6",


### PR DESCRIPTION
With that, someone using CakePHP 3.6+ can update your ElasticSearch instalation without more work