### PR TITLE
[2.x] Split driver and connection and types support

### DIFF
--- a/src/Association/Embedded.php
+++ b/src/Association/Embedded.php
@@ -3,8 +3,8 @@ namespace Cake\ElasticSearch\Association;
 
 use Cake\Core\App;
 use Cake\ElasticSearch\Document;
+use Cake\ElasticSearch\Exception\MissingDocumentException;
 use Cake\ElasticSearch\Index;
-use Cake\ElasticSearch\MissingDocumentException;
 use Cake\Utility\Inflector;
 
 /**

--- a/src/Database/Driver/Elasticsearch.php
+++ b/src/Database/Driver/Elasticsearch.php
@@ -1,0 +1,336 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @internal      Should be used internal only - will be replaced with a real driver in
+ * the future.
+ * @since         2.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Database\Driver;
+
+use Cake\Database\Driver;
+use Cake\Database\Query;
+use Cake\Database\ValueBinder;
+use Elastica\Client as ElasticaClient;
+
+/**
+ * Represents a elasticsearch driver containing all specificities for
+ * a elasticsearch engine including its DSL dialect.
+ */
+class Elasticsearch extends Driver
+{
+    /**
+     * Base configuration settings for ElasticSearch driver
+     *
+     * @var array
+     */
+    protected $_baseConfig = [
+        'host' => 'localhost',
+        'username' => null,
+        'password' => null,
+        'port' => 9200,
+    ];
+
+    /**
+     * Elastica client instance
+     *
+     * @var \Elastica\Client;
+     */
+    protected $_client;
+
+    /**
+     * Constructor.
+     *
+     * @param array $config config options
+     * @param callable $callback Callback function which can be used to be notified
+     * about errors (for example connection down)
+     */
+    public function __construct(array $config = [], $callback = null)
+    {
+        $config += $this->_baseConfig;
+        $this->_config = $config;
+
+        $esLogger = $config['esLogger'];
+        unset($config['esLogger']);
+
+        $this->setConnection(new ElasticaClient($config, $callback, $esLogger));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function connect()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function disconnect()
+    {
+        $this->_client = null;
+    }
+
+    /**
+     * Get the internal Client instance.
+     *
+     * @return \Elastica\Client
+     */
+    public function getConnection()
+    {
+        return $this->_client;
+    }
+
+    /**
+     * Set the internal Client instance.
+     *
+     * @param \Elastica\Client $client instance.
+     * @return $this
+     */
+    public function setConnection($client)
+    {
+        $this->_client = $client;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enabled()
+    {
+        return true;
+    }
+
+    /**
+     * Just return the $query, as we haven't prepared statement
+     * in ElasticSearch context.
+     *
+     * @param string|\Cake\ElasticSearch\Query $query The query.
+     * @return string|\Cake\ElasticSearch\Query $query
+     */
+    public function prepare($query)
+    {
+        return $query;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beginTransaction()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function commitTransaction()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rollbackTransaction()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function releaseSavePointSQL($name)
+    {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function savePointSQL($name)
+    {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rollbackSavePointSQL($name)
+    {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function disableForeignKeySQL()
+    {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enableForeignKeySQL()
+    {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportsDynamicConstraints()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportsSavePoints()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quote($value, $type)
+    {
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportsQuoting()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function queryTranslator($type)
+    {
+        return function ($query) use ($type) {
+            return $query;
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function schemaDialect()
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function quoteIdentifier($identifier)
+    {
+        return $identifier;
+    }
+
+    /**
+     * Escapes values for use in schema definitions.
+     *
+     * @param mixed $value The value to escape.
+     * @return string String for use in schema definitions.
+     */
+    public function schemaValue($value)
+    {
+        return (string)$value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function schema()
+    {
+        return '';
+    }
+
+    /**
+     * Returns last id generated for a index in elasticsearch.
+     *
+     * @param string|null $index index name to get last insert value from.
+     * @param string|null $field the name of the field representing the primary key.
+     * @return string|int
+     */
+    public function lastInsertId($index = null, $field = null)
+    {
+        $search = $this->getConnection()->getIndex($index)->search([
+            'query' => [
+                'match_all' => [],
+            ],
+            'sort' => [
+                '_id' => [
+                    'order' => 'desc',
+                ],
+            ],
+            'size' => 1,
+        ]);
+
+        return $search->current()->_id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isConnected()
+    {
+        return $this->getConnection()->hasConnection();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enableAutoQuoting($enable = true)
+    {
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAutoQuotingEnabled()
+    {
+        return false;
+    }
+
+    /**
+     * Do nothing, as ElasticSearch don't need it.
+     *
+     * @param \Cake\Database\Query $query The query to compile.
+     * @param \Cake\Database\ValueBinder $generator The value binder to use.
+     * @return array .
+     */
+    public function compileQuery(Query $query, ValueBinder $generator)
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function newCompiler()
+    {
+        return null;
+    }
+}

--- a/src/Datasource/MappingSchema.php
+++ b/src/Datasource/MappingSchema.php
@@ -98,7 +98,7 @@ class MappingSchema
     public function fieldType($name)
     {
         $field = $this->field($name);
-        if (!$field) {
+        if (!$field || !isset($field['type'])) {
             return null;
         }
 

--- a/src/Exception/MissingDocumentException.php
+++ b/src/Exception/MissingDocumentException.php
@@ -1,6 +1,4 @@
 <?php
-declare(strict_types=1);
-
 /**
  * MissingDocumentException file
  *
@@ -16,7 +14,7 @@ declare(strict_types=1);
  * @since         2.0.1
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\ElasticSearch;
+namespace Cake\Elasticsearch\Exception;
 
 use Cake\Core\Exception\Exception;
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -23,6 +23,7 @@ use Cake\Datasource\RulesChecker;
 use Cake\ElasticSearch\Association\EmbedMany;
 use Cake\ElasticSearch\Association\EmbedOne;
 use Cake\ElasticSearch\Datasource\MappingSchema;
+use Cake\ElasticSearch\Exception\MissingDocumentException;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
@@ -894,7 +895,7 @@ class Index implements RepositoryInterface, EventListenerInterface, EventDispatc
             $self = get_called_class();
             $parts = explode('\\', $self);
 
-            if ($self === __CLASS__ || count($parts) < 3) {
+            if ($self === self::class || count($parts) < 3) {
                 return $this->_documentClass = $default;
             }
 

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -15,6 +15,7 @@
 namespace Cake\ElasticSearch;
 
 use Cake\Collection\CollectionTrait;
+use Cake\Database\Type;
 use Cake\Datasource\ResultSetInterface;
 use IteratorIterator;
 
@@ -48,6 +49,13 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
     protected $entityClass;
 
     /**
+     * Holds the Elasticsearch Database Driver object
+     *
+     * @var \Cake\ElasticSearch\Database\Driver\Elasticsearch
+     */
+    protected $driver;
+
+    /**
      * Embedded type references
      *
      * @var array
@@ -55,11 +63,18 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
     protected $embeds = [];
 
     /**
-     * Name of the type that the originating query came from.
+     * Name of the index that the originating query came from.
      *
      * @var string
      */
     protected $repoName;
+
+    /**
+     * Map of ElasticSearch field types to Cake\Database\Type
+     *
+     * @var array
+     */
+    protected $map = [];
 
     /**
      * Decorator's constructor
@@ -77,6 +92,10 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
         }
         $this->entityClass = $repo->getEntityClass();
         $this->repoName = $repo->getRegistryAlias();
+        $this->driver = $repo->getConnection()->getDriver();
+        if ($query !== null) {
+            $this->map = $this->_getTypes($repo, $query->clause('fields'));
+        }
         parent::__construct($resultSet);
     }
 
@@ -251,11 +270,16 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
 
         $data = $result->getData();
         $data['id'] = $result->getId();
-
         foreach ($this->embeds as $property => $embed) {
             if (isset($data[$property])) {
                 $data[$property] = $embed->hydrate($data[$property], $options);
             }
+        }
+        foreach ($data as $field => $value) {
+            if (!isset($this->map[$field])) {
+                continue;
+            }
+            $data[$field] = $this->map[$field]->toPHP($value, $this->driver);
         }
 
         $document = new $class($data, $options);
@@ -296,5 +320,43 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
             'items' => $this->resultSet->getResponse()->getData(),
             'query' => $this->resultSet->getQuery(),
         ];
+    }
+
+    /**
+     * Compute and return a map of internal types from a Index mapping type.
+     *
+     * @param  \Cake\ElasticSearch\Index $index The index which results belongs
+     * @param  array $fields Fields included on results
+     * @return array Map of ElasticSearch field type and Cake\Database\Type
+     */
+    protected function _getTypes($index, $fields)
+    {
+        $types = [];
+        $schema = $index->getSchema();
+        $map = array_keys((array)Type::getMap() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
+        $typeMap = array_combine(
+            $map,
+            array_map(['Cake\Database\Type', 'build'], $map)
+        );
+
+        foreach (['string', 'text'] as $t) {
+            if (get_class($typeMap[$t]) === 'Cake\Database\Type') {
+                unset($typeMap[$t]);
+            }
+        }
+
+        $computeFields = $schema->fields();
+        if (!empty($fields)) {
+            $computeFields = array_intersect($fields, $computeFields);
+        }
+        foreach ($computeFields as $field) {
+            $typeName = $schema->fieldType($field);
+
+            if (isset($typeMap[$typeName])) {
+                $types[$field] = $typeMap[$typeName];
+            }
+        }
+
+        return $types;
     }
 }

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -142,6 +142,7 @@ class IndexTest extends TestCase
     public function testGet()
     {
         $connection = $this->getMockBuilder('Cake\ElasticSearch\Datasource\Connection')
+            ->disableOriginalConstructor()
             ->setMethods(['getIndex'])
             ->getMock();
 
@@ -199,6 +200,7 @@ class IndexTest extends TestCase
     public function testNewEntity()
     {
         $connection = $this->getMockBuilder('Cake\ElasticSearch\Datasource\Connection')
+            ->disableOriginalConstructor()
             ->setMethods(['getIndex'])
             ->getMock();
         $index = new Index(
@@ -224,6 +226,7 @@ class IndexTest extends TestCase
     public function testNewEntities()
     {
         $connection = $this->getMockBuilder('Cake\ElasticSearch\Datasource\Connection')
+            ->disableOriginalConstructor()
             ->setMethods(['getIndex'])
             ->getMock();
         $index = new Index(

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -15,6 +15,7 @@
 namespace Cake\ElasticSearch\Test;
 
 use Cake\Datasource\ConnectionManager;
+use Cake\ElasticSearch\Datasource\MappingSchema;
 use Cake\ElasticSearch\Document;
 use Cake\ElasticSearch\Index;
 use Cake\ElasticSearch\ResultSet;
@@ -42,18 +43,24 @@ class ResultSetTest extends TestCase
         $elasticaSet = $this->getMockBuilder('Elastica\ResultSet')
             ->disableOriginalConstructor()
             ->getMock();
-        $type = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
+
+        $connection = ConnectionManager::get('test');
+        $index = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
         $query = $this->getMockBuilder('Cake\ElasticSearch\Query')
-            ->setConstructorArgs([$type])
+            ->setConstructorArgs([$index])
             ->getMock();
         $query->expects($this->once())->method('getRepository')
-            ->will($this->returnValue($type));
-
-        $type->expects($this->once())
+            ->will($this->returnValue($index));
+        $index->expects($this->once())
             ->method('getEntityClass')
             ->will($this->returnValue(__NAMESPACE__ . '\MyTestDocument'));
-        $type->method('embedded')
+        $index->method('embedded')
             ->will($this->returnValue([]));
+        $index->expects($this->once())
+            ->method('getConnection')
+            ->will($this->returnValue($connection));
+        $index->method('getSchema')
+            ->will($this->returnValue(new MappingSchema($index->getType(), [])));
 
         return [new ResultSet($elasticaSet, $query), $elasticaSet];
     }
@@ -93,12 +100,77 @@ class ResultSetTest extends TestCase
     }
 
     /**
+     * Tests that calling current will get converted fields
+     * basic types
+     *
+     * @return void
+     */
+    public function testBasicTypesConversions()
+    {
+        $connection = ConnectionManager::get('test');
+
+        $elasticaSet = $this->getMockBuilder('Elastica\ResultSet')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $index = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
+        $query = $this->getMockBuilder('Cake\ElasticSearch\Query')
+            ->setConstructorArgs([$index])
+            ->getMock();
+        $query->expects($this->once())->method('getRepository')
+            ->will($this->returnValue($index));
+        $index->expects($this->once())
+            ->method('getEntityClass')
+            ->will($this->returnValue(__NAMESPACE__ . '\MyTestDocument'));
+        $index->method('embedded')
+            ->will($this->returnValue([]));
+        $index->expects($this->once())
+            ->method('getConnection')
+            ->will($this->returnValue($connection));
+
+        $mapping = [
+            'foo' => ['type' => 'integer'],
+            'bar' => ['type' => 'keyword'],
+            'baz' => ['type' => 'date'],
+        ];
+        $index->method('getSchema')
+            ->will($this->returnValue(new MappingSchema($index->getType(), $mapping)));
+
+        $data = ['foo' => '1', 'bar' => 'brazil', 'baz' => '2020-05-22'];
+        $result = $this->getMockBuilder('Elastica\Result')
+            ->setMethods(['getId', 'getData', 'getType'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $result->method('getData')
+            ->will($this->returnValue($data));
+        $result->method('getId')
+            ->will($this->returnValue(99));
+        $result->method('getType')
+            ->will($this->returnValue('things'));
+        $elasticaSet->expects($this->once())
+            ->method('current')
+            ->will($this->returnValue($result));
+
+        $resultSet = new ResultSet($elasticaSet, $query);
+
+        $document = $resultSet->current();
+        $this->assertInstanceOf(__NAMESPACE__ . '\MyTestDocument', $document);
+        $this->assertTrue(is_integer($document->foo));
+        $this->assertSame(1, $document->foo);
+        $this->assertTrue(is_string($document->bar));
+        $this->assertSame('brazil', $document->bar);
+        $this->assertInstanceOf('Cake\I18n\Date', $document->baz);
+        $this->assertSame('22/05/2020', $document->baz->format('d/m/Y'));
+    }
+
+    /**
      * Tests that the original ResultSet's methods are accessible
      *
      * @return void
      */
     public function testDecoratedMethods()
     {
+        $connection = ConnectionManager::get('test');
+
         $methods = get_class_methods('Elastica\ResultSet');
         $exclude = [
             '__construct', 'offsetSet', 'offsetGet', 'offsetExists', 'offsetUnset',
@@ -110,15 +182,20 @@ class ResultSetTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods($methods)
             ->getMock();
-        $type = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
-        $type->method('embedded')
+        $index = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
+        $index->method('embedded')
             ->will($this->returnValue([]));
+        $index->expects($this->once())
+            ->method('getConnection')
+            ->will($this->returnValue($connection));
+        $index->method('getSchema')
+            ->will($this->returnValue(new MappingSchema($index->getType(), [])));
         $query = $this->getMockBuilder('Cake\ElasticSearch\Query')
-            ->setConstructorArgs([$type])
+            ->setConstructorArgs([$index])
             ->getMock();
 
         $query->expects($this->once())->method('getRepository')
-            ->will($this->returnValue($type));
+            ->will($this->returnValue($index));
 
         $requireParam = ['getAggregation' => 'foo'];
         $resultSet = new ResultSet($elasticaSet, $query);

--- a/tests/init.php
+++ b/tests/init.php
@@ -57,7 +57,7 @@ Log::setConfig(
 );
 
 if (!getenv('db_dsn')) {
-    putenv('db_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection');
+    putenv('db_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Database\Driver\Elasticsearch');
 }
 
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);


### PR DESCRIPTION
I rewrite my implementation of `typeConversion` branch.

That's include:

1. Split of Connection and Driver code
2. Support to basic type conversion between elasticsearch type and PHP types
3. Tests