### PR TITLE
Test enhancement about assertion equals

### DIFF
--- a/tests/TestCase/Datasource/ConnectionTest.php
+++ b/tests/TestCase/Datasource/ConnectionTest.php
@@ -58,10 +58,10 @@ class ConnectionTest extends TestCase
     {
         $connection = new Connection();
         $index = $connection->getIndex('something_else,another');
-        $this->assertEquals('something_else,another', $index->getName());
+        $this->assertSame('something_else,another', $index->getName());
 
         $index = $connection->getIndex('baz');
-        $this->assertEquals('baz', $index->getName());
+        $this->assertSame('baz', $index->getName());
     }
 
     /**
@@ -107,7 +107,7 @@ class ConnectionTest extends TestCase
             'path' => '_stats',
             'data' => [],
         ], JSON_PRETTY_PRINT);
-        $this->assertEquals('debug ' . $message, $logs[0]);
+        $this->assertSame('debug ' . $message, $logs[0]);
     }
 
     /**

--- a/tests/TestCase/Datasource/MappingSchemaTest.php
+++ b/tests/TestCase/Datasource/MappingSchemaTest.php
@@ -32,7 +32,7 @@ class MappingSchemaTest extends TestCase
     public function testName()
     {
         $mapping = new MappingSchema('articles', []);
-        $this->assertEquals('articles', $mapping->name());
+        $this->assertSame('articles', $mapping->name());
     }
 
     /**
@@ -125,8 +125,8 @@ class MappingSchemaTest extends TestCase
             ],
         ];
         $mapping = new MappingSchema('articles', $data);
-        $this->assertEquals('integer', $mapping->fieldType('user_id'));
-        $this->assertEquals('text', $mapping->fieldType('address.street'));
+        $this->assertSame('integer', $mapping->fieldType('user_id'));
+        $this->assertSame('text', $mapping->fieldType('address.street'));
         $this->assertNull($mapping->fieldType('address.nope'));
     }
 }

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -126,8 +126,8 @@ class DocumentTest extends TestCase
 
         $document = new Document($result);
         $this->assertSame($data + ['id' => 1], $document->toArray());
-        $this->assertEquals('things', $document->type());
-        $this->assertEquals(3, $document->version());
+        $this->assertSame('things', $document->type());
+        $this->assertSame(3, $document->version());
         $this->assertEquals(['highlights array'], $document->highlights());
         $this->assertEquals(['explanation array'], $document->explanation());
     }

--- a/tests/TestCase/EmbeddedDocumentTest.php
+++ b/tests/TestCase/EmbeddedDocumentTest.php
@@ -50,9 +50,9 @@ class EmbeddedDocumentTest extends TestCase
         $assocs = $this->index->embedded();
         $this->assertCount(1, $assocs);
         $this->assertInstanceOf('Cake\ElasticSearch\Association\EmbedOne', $assocs[0]);
-        $this->assertEquals('TestApp\Model\Document\Address', $assocs[0]->getEntityClass());
-        $this->assertEquals('Cake\ElasticSearch\Index', $assocs[0]->getIndexClass());
-        $this->assertEquals('address', $assocs[0]->getProperty());
+        $this->assertSame('TestApp\Model\Document\Address', $assocs[0]->getEntityClass());
+        $this->assertSame('Cake\ElasticSearch\Index', $assocs[0]->getIndexClass());
+        $this->assertSame('address', $assocs[0]->getProperty());
     }
 
     /**
@@ -65,7 +65,7 @@ class EmbeddedDocumentTest extends TestCase
         $this->index->embedOne('Address');
         $result = $this->index->get(1);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result->address);
-        $this->assertEquals('123 street', $result->address->street);
+        $this->assertSame('123 street', $result->address->street);
     }
 
     /**
@@ -102,7 +102,7 @@ class EmbeddedDocumentTest extends TestCase
         $this->index->embedOne('Address', $options);
         $result = $this->index->get(1);
         $this->assertInstanceOf($expected, $result->address);
-        $this->assertEquals('123 street', $result->address->street);
+        $this->assertSame('123 street', $result->address->street);
     }
 
     /**
@@ -129,9 +129,9 @@ class EmbeddedDocumentTest extends TestCase
         $assocs = $this->index->embedded();
         $this->assertCount(1, $assocs);
         $this->assertInstanceOf('Cake\ElasticSearch\Association\EmbedMany', $assocs[0]);
-        $this->assertEquals('TestApp\Model\Document\Address', $assocs[0]->getEntityClass());
-        $this->assertEquals('Cake\ElasticSearch\Index', $assocs[0]->getIndexClass());
-        $this->assertEquals('address', $assocs[0]->getProperty());
+        $this->assertSame('TestApp\Model\Document\Address', $assocs[0]->getEntityClass());
+        $this->assertSame('Cake\ElasticSearch\Index', $assocs[0]->getIndexClass());
+        $this->assertSame('address', $assocs[0]->getProperty());
     }
 
     /**
@@ -194,7 +194,7 @@ class EmbeddedDocumentTest extends TestCase
         $this->index->embedOne('InvalidDocumentName');
         $assocs = $this->index->embedded();
         $this->assertCount(1, $assocs);
-        $this->assertEquals('Cake\ElasticSearch\Document', $assocs[0]->getEntityClass());
-        $this->assertEquals('invalid_document_name', $assocs[0]->getProperty());
+        $this->assertSame('Cake\ElasticSearch\Document', $assocs[0]->getEntityClass());
+        $this->assertSame('invalid_document_name', $assocs[0]->getProperty());
     }
 }

--- a/tests/TestCase/IndexRegistryTest.php
+++ b/tests/TestCase/IndexRegistryTest.php
@@ -89,11 +89,11 @@ class IndexRegistryTest extends TestCase
             ]
         );
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('my_articles', $result->getName());
+        $this->assertSame('my_articles', $result->getName());
 
         $result2 = IndexRegistry::get('Articles');
         $this->assertSame($result, $result2);
-        $this->assertEquals('my_articles', $result->getName());
+        $this->assertSame('my_articles', $result->getName());
     }
 
     /**
@@ -105,11 +105,11 @@ class IndexRegistryTest extends TestCase
     {
         $result = IndexRegistry::get('Droids');
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('droids', $result->getName());
+        $this->assertSame('droids', $result->getName());
 
         $result = IndexRegistry::get('R2D2', ['className' => 'Droids']);
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals(
+        $this->assertSame(
             'r2_d2',
             $result->getName(),
             'The name should be derived from the alias'
@@ -120,19 +120,19 @@ class IndexRegistryTest extends TestCase
             ['className' => 'Droids', 'name' => 'droids']
         );
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('droids', $result->getName(), 'The name should be taken from options');
+        $this->assertSame('droids', $result->getName(), 'The name should be taken from options');
 
         $result = IndexRegistry::get('Funky.Chipmunks');
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('chipmunks', $result->getName(), 'The name should be derived from the alias');
+        $this->assertSame('chipmunks', $result->getName(), 'The name should be derived from the alias');
 
         $result = IndexRegistry::get('Awesome', ['className' => 'Funky.Monkies']);
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('awesome', $result->getName(), 'The name should be derived from the alias');
+        $this->assertSame('awesome', $result->getName(), 'The name should be derived from the alias');
 
         $result = IndexRegistry::get('Stuff', ['className' => 'Cake\ElasticSearch\Index']);
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
-        $this->assertEquals('stuff', $result->getName(), 'The name should be derived from the alias');
+        $this->assertSame('stuff', $result->getName(), 'The name should be derived from the alias');
     }
 
     /**

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -84,7 +84,7 @@ class IndexTest extends TestCase
      */
     public function testGetEntityClassDefault()
     {
-        $this->assertEquals(Document::class, $this->index->getEntityClass());
+        $this->assertSame(Document::class, $this->index->getEntityClass());
     }
 
     /**
@@ -96,7 +96,7 @@ class IndexTest extends TestCase
     {
         $index = IndexRegistry::get('TestPlugin.Comments');
 
-        $this->assertEquals('TestPlugin\Model\Document\Comment', $index->getEntityClass());
+        $this->assertSame('TestPlugin\Model\Document\Comment', $index->getEntityClass());
     }
 
     /**
@@ -109,7 +109,7 @@ class IndexTest extends TestCase
     {
         $index = IndexRegistry::get('Accounts');
 
-        $this->assertEquals(Document::class, $index->getEntityClass());
+        $this->assertSame(Document::class, $index->getEntityClass());
     }
 
     /**
@@ -125,7 +125,7 @@ class IndexTest extends TestCase
 
         $index = new Index();
         $index->setEntityClass('TestUser');
-        $this->assertEquals(
+        $this->assertSame(
             'TestApp\Model\Document\TestUser',
             $index->getEntityClass()
         );
@@ -144,7 +144,7 @@ class IndexTest extends TestCase
 
         $index = new Index();
         $this->assertSame($index, $index->setEntityClass('MyPlugin.SuperUser'));
-        $this->assertEquals(
+        $this->assertSame(
             'MyPlugin\Model\Document\SuperUser',
             $index->getEntityClass()
         );
@@ -237,7 +237,7 @@ class IndexTest extends TestCase
         $this->assertEquals(['a' => 'b', 'id' => 'foo'], $result->toArray());
         $this->assertFalse($result->isDirty());
         $this->assertFalse($result->isNew());
-        $this->assertEquals('foo', $result->getSource());
+        $this->assertSame('foo', $result->getSource());
     }
 
     /**
@@ -262,7 +262,7 @@ class IndexTest extends TestCase
         $result = $index->newEntity($data);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $result);
         $this->assertSame($data, $result->toArray());
-        $this->assertEquals('articles', $result->getSource());
+        $this->assertSame('articles', $result->getSource());
     }
 
     /**
@@ -352,7 +352,7 @@ class IndexTest extends TestCase
         $result = $this->index->get($doc->id);
         $this->assertEquals($doc->title, $result->title);
         $this->assertEquals($doc->body, $result->body);
-        $this->assertEquals('articles', $result->getSource());
+        $this->assertSame('articles', $result->getSource());
     }
 
     /**
@@ -385,7 +385,7 @@ class IndexTest extends TestCase
         $result = $this->index->get($doc->id, ['routing' => 'abcd']);
         $this->assertEquals($doc->title, $result->title);
         $this->assertEquals($doc->body, $result->body);
-        $this->assertEquals('articles', $result->getSource());
+        $this->assertSame('articles', $result->getSource());
     }
 
     /**
@@ -406,7 +406,7 @@ class IndexTest extends TestCase
         $this->assertSame($doc, $this->index->save($doc));
         $this->assertFalse($doc->isNew(), 'Not new.');
         $this->assertFalse($doc->isDirty(), 'Not dirty anymore.');
-        $this->assertEquals('articles', $doc->getSource());
+        $this->assertSame('articles', $doc->getSource());
     }
 
     /**
@@ -487,7 +487,7 @@ class IndexTest extends TestCase
             }
         );
         $this->index->save($doc);
-        $this->assertEquals(2, $called);
+        $this->assertSame(2, $called);
     }
 
     /**
@@ -535,7 +535,7 @@ class IndexTest extends TestCase
 
         $compare = $this->index->get($entity->id);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->user);
-        $this->assertEquals('sarah', $compare->user->username);
+        $this->assertSame('sarah', $compare->user->username);
     }
 
     /**
@@ -561,8 +561,8 @@ class IndexTest extends TestCase
         $compare = $this->index->get($entity->id);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->comments[0]);
         $this->assertInstanceOf('Cake\ElasticSearch\Document', $compare->comments[1]);
-        $this->assertEquals('Nice post', $compare->comments[0]->comment);
-        $this->assertEquals('Awesome!', $compare->comments[1]->comment);
+        $this->assertSame('Nice post', $compare->comments[0]->comment);
+        $this->assertSame('Awesome!', $compare->comments[1]->comment);
     }
 
     /**
@@ -698,7 +698,7 @@ class IndexTest extends TestCase
             }
         );
         $this->assertTrue($this->index->delete($doc));
-        $this->assertEquals(2, $called);
+        $this->assertSame(2, $called);
     }
 
     /**
@@ -766,11 +766,11 @@ class IndexTest extends TestCase
             function ($event, $validator, $name) use (&$called) {
                 $called++;
                 $this->assertInstanceOf('Cake\Validation\Validator', $validator);
-                $this->assertEquals('default', $name);
+                $this->assertSame('default', $name);
             }
         );
         $this->index->getValidator();
-        $this->assertEquals(1, $called, 'Event not triggered');
+        $this->assertSame(1, $called, 'Event not triggered');
     }
 
     /**
@@ -796,7 +796,7 @@ class IndexTest extends TestCase
         $this->connection->getIndex($this->index->getName())->refresh();
 
         $this->assertSame(1, $result);
-        $this->assertEquals(0, $this->index->find()->count());
+        $this->assertSame(0, $this->index->find()->count());
     }
 
     /**
@@ -811,7 +811,7 @@ class IndexTest extends TestCase
         $this->connection->getIndex($this->index->getName())->refresh();
 
         $this->assertSame(1, $result);
-        $this->assertEquals(1, $this->index->find()->count());
+        $this->assertSame(1, $this->index->find()->count());
     }
 
     /**
@@ -847,7 +847,7 @@ class IndexTest extends TestCase
     public function testAlias()
     {
         $this->assertEquals($this->index->getName(), $this->index->getAlias());
-        $this->assertEquals('articles', $this->index->getAlias());
+        $this->assertSame('articles', $this->index->getAlias());
     }
 
     /**
@@ -859,8 +859,8 @@ class IndexTest extends TestCase
     {
         $index = IndexRegistry::get('TestPlugin.Comments');
 
-        $this->assertEquals('articles', $this->index->getRegistryAlias());
-        $this->assertEquals('TestPlugin.Comments', $index->getRegistryAlias());
+        $this->assertSame('articles', $this->index->getRegistryAlias());
+        $this->assertSame('TestPlugin.Comments', $index->getRegistryAlias());
     }
 
     /**

--- a/tests/TestCase/MarshallerTest.php
+++ b/tests/TestCase/MarshallerTest.php
@@ -170,7 +170,7 @@ class MarshallerTest extends TestCase
         $marshaller = new Marshaller($this->index);
         $marshaller->one($data);
 
-        $this->assertEquals(1, $called, 'method should be called');
+        $this->assertSame(1, $called, 'method should be called');
     }
 
     /**
@@ -190,7 +190,7 @@ class MarshallerTest extends TestCase
         });
         $marshaller = new Marshaller($this->index);
         $result = $marshaller->one($data);
-        $this->assertEquals('Mutated', $result->title);
+        $this->assertSame('Mutated', $result->title);
     }
 
     /**
@@ -493,7 +493,7 @@ class MarshallerTest extends TestCase
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $marshaller->merge($doc, $data);
 
-        $this->assertEquals(1, $called, 'method should be called');
+        $this->assertSame(1, $called, 'method should be called');
     }
 
     /**
@@ -514,7 +514,7 @@ class MarshallerTest extends TestCase
         $marshaller = new Marshaller($this->index);
         $doc = new Document(['title' => 'original', 'body' => 'original']);
         $result = $marshaller->merge($doc, $data);
-        $this->assertEquals('Mutated', $result->title);
+        $this->assertSame('Mutated', $result->title);
     }
 
     /**
@@ -729,7 +729,7 @@ class MarshallerTest extends TestCase
         $result = $marshaller->mergeMany($entities, $data);
 
         $this->assertCount(2, $result);
-        $this->assertEquals($data[0]['title'], $result[0]->title);
+        $this->assertSame($data[0]['title'], $result[0]->title);
         $this->assertFalse($result[0]->isNew());
         $this->assertTrue($result[0]->isDirty());
         $this->assertTrue($result[0]->isDirty('title'));

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -578,7 +578,7 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('pre_tags', $compiled['highlight']);
         $this->assertArrayHasKey('post_tags', $compiled['highlight']);
         $this->assertArrayHasKey('fields', $compiled['highlight']);
-        $this->assertEquals(100, $compiled['highlight']['fields']['contents']['fragment_size']);
+        $this->assertSame(100, $compiled['highlight']['fields']['contents']['fragment_size']);
     }
 
     /**

--- a/tests/TestCase/ResultSetTest.php
+++ b/tests/TestCase/ResultSetTest.php
@@ -86,7 +86,7 @@ class ResultSetTest extends TestCase
         $this->assertSame($data + ['id' => 99], $document->toArray());
         $this->assertFalse($document->isDirty());
         $this->assertFalse($document->isNew());
-        $this->assertEquals('things', $document->type());
+        $this->assertSame('things', $document->type());
     }
 
     /**

--- a/tests/TestCase/View/Form/DocumentContextTest.php
+++ b/tests/TestCase/View/Form/DocumentContextTest.php
@@ -266,16 +266,16 @@ class DocumentContextTest extends TestCase
         );
 
         $result = $context->val('0.title');
-        $this->assertEquals('First post', $result);
+        $this->assertSame('First post', $result);
 
         $result = $context->val('0.user.username');
-        $this->assertEquals('mark', $result);
+        $this->assertSame('mark', $result);
 
         $result = $context->val('1.title');
-        $this->assertEquals('Second post', $result);
+        $this->assertSame('Second post', $result);
 
         $result = $context->val('1.user.username');
-        $this->assertEquals('jose', $result);
+        $this->assertSame('jose', $result);
 
         $this->assertNull($context->val('nope'));
         $this->assertNull($context->val('99.title'));
@@ -570,7 +570,7 @@ class DocumentContextTest extends TestCase
 
         $this->assertEquals($this->textField, $context->type('title'));
         $this->assertEquals($this->textField, $context->type('body'));
-        $this->assertEquals('integer', $context->type('user_id'));
+        $this->assertSame('integer', $context->type('user_id'));
         $this->assertNull($context->type('nope'));
     }
 


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assertion equals strict.