### PR TITLE
Add Composer constraint for CakePHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "source": "https://github.com/cakephp/elastic-search"
     },
     "require": {
+        "cakephp/cakephp": "^4.0",
         "ruflin/elastica": "^6.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^4.0",
         "cakephp/cakephp-codesniffer": "^4.0",
         "phpunit/phpunit": "^8.5"
     },

--- a/src/Marshaller.php
+++ b/src/Marshaller.php
@@ -293,14 +293,16 @@ class Marshaller
     public function mergeMany(array $entities, array $data, array $options = [])
     {
         $indexed = (new Collection($data))
-            ->groupBy('id')
+            ->groupBy(function ($element) {
+                return $element['id'] ?? '';
+            })
             ->map(function ($element, $key) {
                 return $key === '' ? $element : $element[0];
             })
             ->toArray();
 
-        $new = $indexed[null] ?? [];
-        unset($indexed[null]);
+        $new = $indexed[''] ?? [];
+        unset($indexed['']);
 
         $output = [];
         foreach ($entities as $record) {


### PR DESCRIPTION
Prevent installing Elasticsearch 3 with CakePHP 3.

Fixes #248.