### PR TITLE
2.x - Add cakephp requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "source": "https://github.com/cakephp/elastic-search"
     },
     "require": {
+        "cakephp/cakephp": "^3.6",
         "ruflin/elastica": "^6.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "^3.6",
         "cakephp/cakephp-codesniffer": "^3.0",
         "psr/log": "~1.0",
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
Add cakephp requirement to composer the same as https://github.com/cakephp/elastic-search/pull/250.

If we don't add it to 2.x, then that doesn't prevent the original issue.