### PR TITLE
Upgrade to Elastica 7 and enable tests for PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4']
+        php-version: ['7.2', '7.4', '8.0']
         prefer-lowest: ['']
         include:
           - php-version: '7.2'
@@ -22,9 +22,10 @@ jobs:
 
     services:
       elasticsearch:
-        image: elasticsearch:6.8.13
+        image: elasticsearch:7.10.1
         ports:
           - 9200/tcp
+        options: -e "discovery.type=single-node"
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -145,16 +145,6 @@ class CommentsIndex extends Index
     {
         return 'comments';
     }
-
-    /**
-     * The name of mapping type in Elasticsearch
-     *
-     * @return  string
-     */
-    public function getType()
-    {
-        return 'comments';
-    }
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "cakephp/cakephp": "^4.0",
-        "ruflin/elastica": "^6.0"
+        "ruflin/elastica": "^7.1"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -59,11 +59,6 @@ class in elasticsearch::
     {
     }
 
-Index objects will assume that the type mapping name for your index is the
-singular version of the index name. In our example the type mapping would be
-``article``. If you need to change the type mapping name use the ``setType()``
-method.
-
 You can then use your index class in your controllers::
 
     public function beforeFilter(Event $event)
@@ -230,7 +225,7 @@ use ``embedOne`` and ``embedMany`` to define embedded documents::
 
     use Cake\ElasticSearch\Index;
 
-    class ArticlesType extends Index
+    class ArticlesIndex extends Index
     {
         public function initialize()
         {

--- a/src/Datasource/MappingSchema.php
+++ b/src/Datasource/MappingSchema.php
@@ -29,7 +29,7 @@ class MappingSchema
     protected $data;
 
     /**
-     * The name of the type this mapping data is for.
+     * The name of the index this mapping data is for.
      *
      * @var string
      */
@@ -38,20 +38,20 @@ class MappingSchema
     /**
      * Constructor
      *
-     * @param string $name The name of the type of the mapping data
+     * @param string $name The name of the index of the mapping data
      * @param array $data The mapping data from elasticsearch
      */
     public function __construct($name, array $data)
     {
         $this->name = $name;
-        if (isset($data[$name]['properties'])) {
-            $data = $data[$name]['properties'];
+        if (isset($data['properties'])) {
+            $data = $data['properties'];
         }
         $this->data = $data;
     }
 
     /**
-     * Get the name of the type for this mapping.
+     * Get the name of the index for this mapping.
      *
      * @return string
      */

--- a/src/Document.php
+++ b/src/Document.php
@@ -96,16 +96,16 @@ class Document implements EntityInterface
     }
 
     /**
-     * Returns the Elasticsearch type name from which this document came from.
+     * Returns the Elasticsearch index name from which this document came from.
      *
      * If this is a new document, this function returns null
      *
      * @return string|null
      */
-    public function type()
+    public function index()
     {
         if ($this->_result) {
-            return $this->_result->getType();
+            return $this->_result->getIndex();
         }
 
         return null;

--- a/src/Query.php
+++ b/src/Query.php
@@ -18,6 +18,7 @@ namespace Cake\ElasticSearch;
 
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\QueryTrait;
+use Cake\Datasource\ResultSetInterface;
 use Elastica\Query as ElasticaQuery;
 use Elastica\Query\AbstractQuery;
 use IteratorAggregate;
@@ -618,7 +619,7 @@ class Query implements IteratorAggregate, QueryInterface
      *
      * @return \Cake\ElasticSearch\ResultSet The results of the query
      */
-    protected function _execute()
+    protected function _execute(): ResultSetInterface
     {
         $connection = $this->_repository->getConnection();
         $index = $this->_repository->getName();

--- a/src/Query.php
+++ b/src/Query.php
@@ -81,7 +81,7 @@ class Query implements IteratorAggregate, QueryInterface
     protected $_dirty = false;
 
     /**
-     * Additional options for Elastica\Type::search()
+     * Additional options for Elastica\Index::search()
      *
      * @see \Elastica\Search::OPTION_SEARCH_* constants
      * @var array
@@ -622,11 +622,11 @@ class Query implements IteratorAggregate, QueryInterface
     {
         $connection = $this->_repository->getConnection();
         $index = $this->_repository->getName();
-        $type = $connection->getIndex($index)->getType($this->_repository->getType());
+        $esIndex = $connection->getIndex($index);
 
         $query = $this->compileQuery();
 
-        return new ResultSet($type->search($query, $this->_searchOptions), $this);
+        return new ResultSet($esIndex->search($query, $this->_searchOptions), $this);
     }
 
     /**
@@ -706,12 +706,12 @@ class Query implements IteratorAggregate, QueryInterface
     {
         $connection = $this->_repository->getConnection();
         $index = $this->_repository->getName();
-        $type = $connection->getIndex($index)->getType($this->_repository->getType());
+        $esIndex = $connection->getIndex($index);
 
         $query = clone $this->compileQuery();
         $query->setSize(0);
         $query->setSource(false);
 
-        return $type->search($query)->getTotalHits();
+        return $esIndex->search($query)->getTotalHits();
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -174,15 +174,14 @@ class QueryBuilder
      *
      * @param string $field The field to compare.
      * @param string $id The ID of the document containing the pre-indexed shape.
-     * @param string $type Index type where the pre-indexed shape is.
      * @param string $index Name of the index where the pre-indexed shape is.
      * @param string $path The field specified as path containing the pre-indexed shape.
      * @return \Elastica\Query\GeoShapePreIndexed
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
      */
-    public function geoShapeIndex($field, $id, $type, $index = 'shapes', $path = 'shape')
+    public function geoShapeIndex($field, $id, $index = 'shapes', $path = 'shape')
     {
-        return new Elastica\Query\GeoShapePreIndexed($field, $id, $type, $index, $path);
+        return new Elastica\Query\GeoShapePreIndexed($field, $id, $index, $path);
     }
 
     /**
@@ -493,24 +492,6 @@ class QueryBuilder
     public function terms($field, $values)
     {
         return new Elastica\Query\Terms($field, $values);
-    }
-
-    /**
-     * Returns a Type query object that query documents matching the provided document/mapping type.
-     *
-     * ### Example:
-     *
-     * {{{
-     *  $builder->type('products');
-     * }}}
-     *
-     * @param string $type The type name
-     * @return \Elastica\Query\Type
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
-     */
-    public function type($type)
-    {
-        return new Elastica\Query\Type($type);
     }
 
     /**

--- a/src/TestSuite/TestFixture.php
+++ b/src/TestSuite/TestFixture.php
@@ -48,6 +48,13 @@ class TestFixture implements FixtureInterface
     public $connection = 'test';
 
     /**
+     * The index settings used to create the underlying index.
+     *
+     * @var array
+     */
+    public $indexSettings = [];
+
+    /**
      * The Elastic search type mapping definition for this type.
      *
      * The schema defined here should be compatible with Elasticsearch's
@@ -131,7 +138,12 @@ class TestFixture implements FixtureInterface
         if ($esIndex->exists()) {
             $esIndex->delete();
         }
-        $esIndex->create();
+
+        $args = [];
+        if (!empty($this->indexSettings)) {
+            $args['settings'] = $this->indexSettings;
+        }
+        $esIndex->create($args);
 
         $mapping = new ElasticaMapping();
         $mapping->setProperties($this->schema);

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -29,6 +29,16 @@ class ArticlesFixture extends TestFixture
     public $table = 'articles';
 
     /**
+     * The index settings used to create the underlying index.
+     *
+     * @var array
+     */
+    public $indexSettings = [
+        'number_of_shards' => 2,
+        'number_of_routing_shards' => 2,
+    ];
+
+    /**
      * The mapping data.
      *
      * @var array

--- a/tests/TestCase/DocumentTest.php
+++ b/tests/TestCase/DocumentTest.php
@@ -80,7 +80,7 @@ class DocumentTest extends TestCase
     public function testNewWithNoResult()
     {
         $document = new Document();
-        $this->assertNull($document->type());
+        $this->assertNull($document->index());
         $this->assertSame(1, $document->version());
         $this->assertEquals([], $document->highlights());
         $this->assertEquals([], $document->explanation());
@@ -95,7 +95,7 @@ class DocumentTest extends TestCase
     public function testTypeWithResult()
     {
         $result = $this->getMockBuilder('Elastica\Result')
-            ->setMethods(['getData', 'getId', 'getType', 'getVersion', 'getHighlights', 'getExplanation'])
+            ->setMethods(['getData', 'getId', 'getIndex', 'getVersion', 'getHighlights', 'getExplanation'])
             ->disableOriginalConstructor()
             ->getMock();
         $data = ['a' => 'b'];
@@ -109,7 +109,7 @@ class DocumentTest extends TestCase
             ->will($this->returnValue(1));
 
         $result
-            ->method('getType')
+            ->method('getIndex')
             ->will($this->returnValue('things'));
 
         $result
@@ -126,7 +126,7 @@ class DocumentTest extends TestCase
 
         $document = new Document($result);
         $this->assertSame($data + ['id' => 1], $document->toArray());
-        $this->assertSame('things', $document->type());
+        $this->assertSame('things', $document->index());
         $this->assertSame(3, $document->version());
         $this->assertEquals(['highlights array'], $document->highlights());
         $this->assertEquals(['explanation array'], $document->explanation());

--- a/tests/TestCase/IndexTest.php
+++ b/tests/TestCase/IndexTest.php
@@ -205,22 +205,14 @@ class IndexTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $internalType = $this->getMockBuilder('Elastica\Type')
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $connection->expects($this->once())
             ->method('getIndex')
             ->will($this->returnValue($internalIndex));
 
-        $internalIndex->expects($this->once())
-            ->method('getType')
-            ->will($this->returnValue($internalType));
-
         $document = $this->getMockBuilder('Elastica\Document')
             ->setMethods(['getId', 'getData'])
             ->getMock();
-        $internalType->expects($this->once())
+        $internalIndex->expects($this->once())
             ->method('getDocument')
             ->with('foo', ['bar' => 'baz'])
             ->will($this->returnValue($document));
@@ -588,7 +580,7 @@ class IndexTest extends TestCase
         $this->assertFalse($this->index->save($doc), 'Save should fail');
 
         $doc->clean();
-        $doc->id = 12345;
+        $doc->id = '12345';
         $doc->setNew(false);
         $this->assertSame($doc, $this->index->save($doc), 'Save should pass, not new anymore.');
     }

--- a/tests/TestCase/QueryBuilderTest.php
+++ b/tests/TestCase/QueryBuilderTest.php
@@ -183,14 +183,13 @@ class QueryBuilderTest extends TestCase
     public function testGeoShapeIndex()
     {
         $builder = new QueryBuilder();
-        $result = $builder->geoShapeIndex('location', 'DEU', 'countries', 'shapes', 'location');
+        $result = $builder->geoShapeIndex('location', 'DEU', 'shapes', 'location');
         $expected = [
             'geo_shape' => [
                 'location' => [
                     'relation' => 'intersects',
                     'indexed_shape' => [
                         'id' => 'DEU',
-                        'type' => 'countries',
                         'index' => 'shapes',
                         'path' => 'location',
                     ],
@@ -557,21 +556,6 @@ class QueryBuilderTest extends TestCase
         $result = $builder->terms('user.name', ['mark', 'jose']);
         $expected = [
             'terms' => ['user.name' => ['mark', 'jose']],
-        ];
-        $this->assertEquals($expected, $result->toArray());
-    }
-
-    /**
-     * Tests the type() filter
-     *
-     * @return void
-     */
-    public function testType()
-    {
-        $builder = new QueryBuilder();
-        $result = $builder->type('products');
-        $expected = [
-            'type' => ['value' => 'products'],
         ];
         $this->assertEquals($expected, $result->toArray());
     }

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -592,6 +592,6 @@ class QueryTest extends TestCase
         $query = new Query($index);
         $this->assertSame($query, $query->withMinScore(1));
         $elasticQuery = $query->compileQuery()->toArray();
-        $this->assertSame(1, $elasticQuery['min_score']);
+        $this->assertSame(1.0, $elasticQuery['min_score']);
     }
 }

--- a/tests/testapp/TestApp/src/Model/Index/AccountsIndex.php
+++ b/tests/testapp/TestApp/src/Model/Index/AccountsIndex.php
@@ -18,9 +18,4 @@ class AccountsIndex extends Index
     {
         return 'accounts';
     }
-
-    public function getType()
-    {
-        return 'accounts';
-    }
 }

--- a/tests/testapp/TestApp/src/Model/Index/UsersIndex.php
+++ b/tests/testapp/TestApp/src/Model/Index/UsersIndex.php
@@ -18,9 +18,4 @@ class UsersIndex extends Index
     {
         return 'users';
     }
-
-    public function getType()
-    {
-        return 'users';
-    }
 }


### PR DESCRIPTION
Note: this is an early draft to get all the tests passing. I did not yet have a chance to test this in our application, or check for correctness of the changes. I'm submitting here for visibility and to get some early feedback.

Notable changes:

- Mapping types are removed in Elastica 7, so I replaced them with the equivalent Index methods everywhere
- I've enabled tests for PHP 8.0 and fixed the missing return type. I think the return type may be backported to 3.x to ease upgrading
- Breaking: I removed `Document::getType()` since it is no longer applicable
- Breaking: `QueryBuilder::geoShapeIndex()` has changed arguments
- The tests for routing keys need an index with the correct number of routing shards in ES 7. I needed to extend the TestFixture for this.
- `ResultSetTest::testDecoratedMethods()` is rather fragile with the new strict return types in Elastica 7. I've worked around this issue for now, but it should probably be refactored.