### PR TITLE
5.x Add a local development environment for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '8.0', '8.1']
+        php-version: ['8.1']
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '8.1'
             prefer-lowest: 'prefer-lowest'
 
     services:
@@ -68,26 +68,26 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.1'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
       env:
         DB_URL: Cake\ElasticSearch\Datasource\Connection://127.0.0.1:${{ job.services.elasticsearch.ports['9200'] }}?driver=Cake\ElasticSearch\Datasource\Connection
       run: |
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.1'
       uses: codecov/codecov-action@v1
 
   cs-stan:
     name: Coding Standard & Static Analysis
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-21.10
 
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '8.1'
         extensions: mbstring, intl, apcu
         tools: cs2pr
         coverage: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   cs-stan:
     name: Coding Standard & Static Analysis
-    runs-on: ubuntu-21.10
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,14 @@ RUN apt-get update && \
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php && \
   apt-get update && \
   apt-get install -y \
-    php8.1-cli php8.1-mbstring php8.1-xml php8.1-zip php8.1-intl php8.1-opcache php8.1-sqlite php8.1-curl \
+    php8.1-cli \
+    php8.1-mbstring \
+    php8.1-xml \
+    php8.1-zip \
+    php8.1-intl \
+    php8.1-opcache \
+    php8.1-sqlite \
+    php8.1-curl \
     composer
 
 RUN composer self-update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # Basic docker based environment
 # Necessary to trick dokku into building the documentation
 # using dockerfile instead of herokuish
-FROM ubuntu:17.04
+FROM ubuntu:21.10
+
+ENV TZ="Etc/UTC"
+RUN apt-get update && \
+  apt-get install -y tzdata && \
+  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+  dpkg-reconfigure -f noninteractive tzdata
 
 # Add basic tools
 RUN apt-get update && \
@@ -15,10 +21,16 @@ RUN apt-get update && \
 
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php && \
   apt-get update && \
-  apt-get install -y php7.2-cli php7.2-mbstring php7.2-xml php7.2-zip php7.2-intl php7.2-opcache php7.2-sqlite
+  apt-get install -y \
+    php8.1-cli php8.1-mbstring php8.1-xml php8.1-zip php8.1-intl php8.1-opcache php8.1-sqlite php8.1-curl \
+    composer
+
+RUN composer self-update && \
+  # This prevents permission errors with the mounted vendor directory.
+  git config --global --add safe.directory /code/vendor/cakephp/cakephp
 
 WORKDIR /code
 
 VOLUME ["/code"]
 
-CMD [ '/bin/bash' ]
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ class CommentsIndex extends Index
 
 ## Running tests
 
+We recommend using the included `docker-compose.yml` for doing local
+development. The `Dockerfile` contains the development environment, and an
+Elasticsearch container will be downloaded and started on port 9200.
+
+```bash
+# Start elasticsearch
+docker-compose up -d
+
+# Open an terminal in the development environment
+docker-compose run console bash
+```
+
+Once inside the container you can install dependencies and run tests.
+
+```bash
+./composer.phar install
+vendor/bin/phpunit
+```
+
 **Warning**: Please, be very carefully when running tests as the Fixture will
 create and drop Elasticsearch indexes for its internal structure. Don't run tests
 in production or development machines where you have important data into your

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^4.0",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.5.19"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
             "TestPluginTwo\\": "tests/testapp/Plugin/TestPluginTwo/src"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts": {
         "check": [
             "@test",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  console:
+    build: "."
+    environment:
+      DB_URL: "Cake\\ElasticSearch\\Datasource\\Connection://elasticsearch:9200?driver=Cake\\ElasticSearch\\Datasource\\Connection"
+    volumes:
+      - .:/code
+  elasticsearch:
+    image: "elasticsearch:7.17.4"
+    ports:
+      - 9200/tcp
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms500m -Xmx500m
+    healthcheck:
+      test: "curl -f http://127.0.0.1:9200/_cluster/health || exit 1"
+      interval: "10s"
+      timeout: "5s"
+      retries: 10
+      start_period: "30s"


### PR DESCRIPTION
I've used this docker-compose environment to run tests locally and they all passed with 4.x. I'll use this to get the tests passing against cake5.