### PR TITLE
3.x - Add locator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,8 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php && \
     php8.1-curl \
     composer
 
-RUN composer self-update && \
-  # This prevents permission errors with the mounted vendor directory.
-  git config --global --add safe.directory /code/vendor/cakephp/cakephp
+# This prevents permission errors with the mounted vendor directory.
+RUN git config --global --add safe.directory /code/vendor/cakephp/cakephp
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # Basic docker based environment
 # Necessary to trick dokku into building the documentation
 # using dockerfile instead of herokuish
-FROM ubuntu:17.04
+FROM ubuntu:21.10
+
+ENV TZ="Etc/UTC"
+RUN apt-get update && \
+  apt-get install -y tzdata && \
+  ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+  dpkg-reconfigure -f noninteractive tzdata
 
 # Add basic tools
 RUN apt-get update && \
@@ -15,10 +21,23 @@ RUN apt-get update && \
 
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php && \
   apt-get update && \
-  apt-get install -y php7.2-cli php7.2-mbstring php7.2-xml php7.2-zip php7.2-intl php7.2-opcache php7.2-sqlite
+  apt-get install -y \
+    php8.1-cli \
+    php8.1-mbstring \
+    php8.1-xml \
+    php8.1-zip \
+    php8.1-intl \
+    php8.1-opcache \
+    php8.1-sqlite \
+    php8.1-curl \
+    composer
+
+RUN composer self-update && \
+  # This prevents permission errors with the mounted vendor directory.
+  git config --global --add safe.directory /code/vendor/cakephp/cakephp
 
 WORKDIR /code
 
 VOLUME ["/code"]
 
-CMD [ '/bin/bash' ]
+CMD [ "/bin/bash" ]

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
             "TestPluginTwo\\": "tests/testapp/Plugin/TestPluginTwo/src"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts": {
         "check": [
             "@test",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  console:
+    build: "."
+    environment:
+      DB_URL: "Cake\\ElasticSearch\\Datasource\\Connection://elasticsearch:9200?driver=Cake\\ElasticSearch\\Datasource\\Connection"
+    volumes:
+      - .:/code
+  elasticsearch:
+    image: "elasticsearch:7.17.4"
+    ports:
+      - 9200/tcp
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: -Xms500m -Xmx500m
+    healthcheck:
+      test: "curl -f http://127.0.0.1:9200/_cluster/health || exit 1"
+      interval: "10s"
+      timeout: "5s"
+      retries: 10
+      start_period: "30s"

--- a/src/Datasource/IndexLocator.php
+++ b/src/Datasource/IndexLocator.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
  * @since     3.5.0
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Elasticsearch\Datasource;
+namespace Cake\ElasticSearch\Datasource;
 
 use Cake\Core\App;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\Locator\AbstractLocator;
-use Cake\Elasticsearch\Index;
+use Cake\ElasticSearch\Index;
 use Cake\Utility\Inflector;
 
 /**

--- a/src/Datasource/IndexLocator.php
+++ b/src/Datasource/IndexLocator.php
@@ -83,11 +83,10 @@ class IndexLocator extends AbstractLocator
     protected function createInstance(string $alias, array $options)
     {
         [, $classAlias] = pluginSplit($alias);
-        $options += ['name' => Inflector::underscore($classAlias)];
-
-        if (empty($options['className'])) {
-            $options['className'] = Inflector::camelize($alias);
-        }
+        $options += [
+            'name' => Inflector::underscore($classAlias),
+            'className' => Inflector::camelize($alias),
+        ];
         $className = App::className($options['className'], 'Model/Index', 'Index');
         if ($className) {
             $options['className'] = $className;

--- a/src/Datasource/IndexLocator.php
+++ b/src/Datasource/IndexLocator.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     3.5.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Elasticsearch\Datasource;
+
+use Cake\Core\App;
+use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\Locator\AbstractLocator;
+use Cake\Elasticsearch\Index;
+use Cake\Utility\Inflector;
+
+/**
+ * Datasource FactoryLocator compatible locater implementation.
+ */
+class IndexLocator extends AbstractLocator
+{
+    /**
+     * Fallback class to use
+     *
+     * @var string
+     * @psalm-var class-string<\Cake\Elasticsearch\Index>
+     */
+    protected $fallbackClassName = Index::class;
+
+    /**
+     * Whether fallback class should be used if a Index class could not be found.
+     *
+     * @var bool
+     */
+    protected $allowFallbackClass = true;
+
+    /**
+     * Set fallback class name.
+     *
+     * The class that should be used to create a table instance if a concrete
+     * class for alias used in `get()` could not be found. Defaults to
+     * `Cake\Elasticsearch\Index`.
+     *
+     * @param string $className Fallback class name
+     * @return $this
+     * @psalm-param class-string<\Cake\Elasticsearch\Index> $className
+     */
+    public function setFallbackClassName($className)
+    {
+        $this->fallbackClassName = $className;
+
+        return $this;
+    }
+
+    /**
+     * Set if fallback class should be used.
+     *
+     * Controls whether a fallback class should be used to create a index
+     * instance if a concrete class for alias used in `get()` could not be found.
+     *
+     * @param bool $allow Flag to enable or disable fallback
+     * @return $this
+     */
+    public function allowFallbackClass(bool $allow)
+    {
+        $this->allowFallbackClass = $allow;
+
+        return $this;
+    }
+
+    protected function createInstance(string $alias, array $options)
+    {
+        [, $classAlias] = pluginSplit($alias);
+        $options += ['name' => Inflector::underscore($classAlias)];
+
+        if (empty($options['className'])) {
+            $options['className'] = Inflector::camelize($alias);
+        }
+        $className = App::className($options['className'], 'Model/Index', 'Index');
+        if ($className) {
+            $options['className'] = $className;
+        } else {
+            if (!isset($options['name']) && strpos($options['className'], '\\') === false) {
+                [, $name] = pluginSplit($options['className']);
+                $options['name'] = Inflector::underscore($name);
+            }
+            $options['className'] = $this->fallbackClassName;
+        }
+
+        if (empty($options['connection'])) {
+            $connectionName = $options['className']::defaultConnectionName();
+            $options['connection'] = ConnectionManager::get($connectionName);
+        }
+        $options['registryAlias'] = $alias;
+
+        return new $options['className']($options);
+    }
+}

--- a/src/Datasource/IndexLocator.php
+++ b/src/Datasource/IndexLocator.php
@@ -52,7 +52,7 @@ class IndexLocator extends AbstractLocator
      * @return $this
      * @psalm-param class-string<\Cake\Elasticsearch\Index> $className
      */
-    public function setFallbackClassName($className)
+    public function setFallbackClassName(string $className)
     {
         $this->fallbackClassName = $className;
 

--- a/src/Exception/MissingIndexClassException.php
+++ b/src/Exception/MissingIndexClassException.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MissingDocumentException file
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Exception;
+
+use Cake\Core\Exception\CakeException;
+
+/**
+ * Exception raised when an index class cannot be found
+ */
+class MissingIndexClassException extends CakeException
+{
+    /**
+     * @var string
+     */
+    protected $_messageTemplate = 'Index class %s could not be found.';
+}

--- a/src/IndexRegistry.php
+++ b/src/IndexRegistry.php
@@ -16,11 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ElasticSearch;
 
-use Cake\Core\App;
-use Cake\Datasource\ConnectionManager;
 use Cake\ElasticSearch\Datasource\IndexLocator;
-use Cake\Utility\Inflector;
-use RuntimeException;
 
 /**
  * Factory/Registry class for Index objects.
@@ -29,6 +25,7 @@ use RuntimeException;
  * created and that the correct connection is injected in.
  *
  * Provides an interface similar to Cake\ORM\TableRegistry.
+ *
  * @deprecated 3.4.3 Statically accesible registry is deprecated. Prefer using `IndexLocator`
  *   alongside the `LocatorTrait` in CakePHP.
  */
@@ -37,10 +34,15 @@ class IndexRegistry
     /**
      * The locator that the global registy is wrapping.
      *
-     * @var Cake\ElasticSearch\Datasource\IndexLocator
+     * @var \Cake\ElasticSearch\Cake\ElasticSearch\Datasource\IndexLocator
      */
     protected static $locator;
 
+    /**
+     * Get the wrapped locator.
+     *
+     * @return \Cake\ElasticSearch\IndexLocator
+     */
     protected static function getLocator(): IndexLocator
     {
         if (static::$locator === null) {
@@ -110,7 +112,7 @@ class IndexRegistry
      */
     public static function clear()
     {
-        return static::getLocator()->clear();
+        static::getLocator()->clear();
     }
 
     /**
@@ -121,6 +123,6 @@ class IndexRegistry
      */
     public static function remove($alias)
     {
-        return static::getLocator()->remove($alias);
+        static::getLocator()->remove($alias);
     }
 }

--- a/src/IndexRegistry.php
+++ b/src/IndexRegistry.php
@@ -18,6 +18,7 @@ namespace Cake\ElasticSearch;
 
 use Cake\Core\App;
 use Cake\Datasource\ConnectionManager;
+use Cake\ElasticSearch\Datasource\IndexLocator;
 use Cake\Utility\Inflector;
 use RuntimeException;
 
@@ -28,29 +29,26 @@ use RuntimeException;
  * created and that the correct connection is injected in.
  *
  * Provides an interface similar to Cake\ORM\TableRegistry.
+ * @deprecated 3.4.3 Statically accesible registry is deprecated. Prefer using `IndexLocator`
+ *   alongside the `LocatorTrait` in CakePHP.
  */
 class IndexRegistry
 {
     /**
-     * The map of instances in the registry.
+     * The locator that the global registy is wrapping.
      *
-     * @var array
+     * @var Cake\ElasticSearch\Datasource\IndexLocator
      */
-    protected static $instances = [];
+    protected static $locator;
 
-    /**
-     * List of options by alias passed to get.
-     *
-     * @var array
-     */
-    protected static $options = [];
+    protected static function getLocator(): IndexLocator
+    {
+        if (static::$locator === null) {
+            static::$locator = new IndexLocator();
+        }
 
-    /**
-     * Fallback class to use
-     *
-     * @var string
-     */
-    protected static $fallbackClassName = Index::class;
+        return static::$locator;
+    }
 
     /**
      * Set fallback class name.
@@ -64,7 +62,7 @@ class IndexRegistry
      */
     public static function setFallbackClassName($className)
     {
-        static::$fallbackClassName = $className;
+        static::getLocator()->setFallbackClassName($className);
     }
 
     /**
@@ -79,43 +77,7 @@ class IndexRegistry
      */
     public static function get($alias, array $options = [])
     {
-        if (isset(static::$instances[$alias])) {
-            if (!empty($options) && static::$options[$alias] !== $options) {
-                throw new RuntimeException(sprintf(
-                    'You cannot configure "%s", it already exists in the registry.',
-                    $alias
-                ));
-            }
-
-            return static::$instances[$alias];
-        }
-
-        static::$options[$alias] = $options;
-        [, $classAlias] = pluginSplit($alias);
-        $options += ['name' => Inflector::underscore($classAlias)];
-
-        if (empty($options['className'])) {
-            $options['className'] = Inflector::camelize($alias);
-        }
-        $className = App::className($options['className'], 'Model/Index', 'Index');
-        if ($className) {
-            $options['className'] = $className;
-        } else {
-            if (!isset($options['name']) && strpos($options['className'], '\\') === false) {
-                [, $name] = pluginSplit($options['className']);
-                $options['name'] = Inflector::underscore($name);
-            }
-            $options['className'] = static::$fallbackClassName;
-        }
-
-        if (empty($options['connection'])) {
-            $connectionName = $options['className']::defaultConnectionName();
-            $options['connection'] = ConnectionManager::get($connectionName);
-        }
-        $options['registryAlias'] = $alias;
-        static::$instances[$alias] = new $options['className']($options);
-
-        return static::$instances[$alias];
+        return static::getLocator()->get($alias, $options);
     }
 
     /**
@@ -126,7 +88,7 @@ class IndexRegistry
      */
     public static function exists($alias)
     {
-        return isset(static::$instances[$alias]);
+        return static::getLocator()->exists($alias);
     }
 
     /**
@@ -138,7 +100,7 @@ class IndexRegistry
      */
     public static function set($alias, Index $object)
     {
-        return static::$instances[$alias] = $object;
+        return static::getLocator()->set($alias, $object);
     }
 
     /**
@@ -148,7 +110,7 @@ class IndexRegistry
      */
     public static function clear()
     {
-        static::$instances = [];
+        return static::getLocator()->clear();
     }
 
     /**
@@ -159,6 +121,6 @@ class IndexRegistry
      */
     public static function remove($alias)
     {
-        unset(static::$instances[$alias]);
+        return static::getLocator()->remove($alias);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Datasource\FactoryLocator;
+use Cake\ElasticSearch\Datasource\IndexLocator;
 use Cake\ElasticSearch\View\Form\DocumentContext;
 use Cake\Event\EventManager;
 use Traversable;
@@ -34,9 +35,9 @@ class Plugin extends BasePlugin
      */
     public function bootstrap(PluginApplicationInterface $app): void
     {
-        $callback = ['Cake\ElasticSearch\IndexRegistry', 'get'];
-        FactoryLocator::add('Elastic', $callback);
-        FactoryLocator::add('ElasticSearch', $callback);
+        $locator = new IndexLocator();
+        FactoryLocator::add('Elastic', $locator);
+        FactoryLocator::add('ElasticSearch', $locator);
 
         // Attach the document context into FormHelper.
         EventManager::instance()->on('View.beforeRender', function ($event) {

--- a/tests/TestCase/Datasource/IndexLocatorTest.php
+++ b/tests/TestCase/Datasource/IndexLocatorTest.php
@@ -1,0 +1,356 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link      http://cakephp.org CakePHP(tm) Project
+ * @since     0.5.0
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ElasticSearch\Test\TestCase\Datasource;
+
+use Cake\Core\Configure;
+use Cake\ElasticSearch\Index;
+use Cake\ElasticSearch\Datasource\IndexLocator;;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for IndexLocator
+ */
+class IndexLocatorTest extends TestCase
+{
+    /**
+     * setup
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('App.namespace', 'TestApp');
+
+        $this->locator = new IndexLocator();
+    }
+
+    /**
+     * Test the exists() method.
+     *
+     * @return void
+     */
+    public function testExists()
+    {
+        $this->assertFalse($this->locator->exists('Articles'));
+
+        $this->locator->get('Articles', ['name' => 'articles']);
+        $this->assertTrue($this->locator->exists('Articles'));
+    }
+
+    /**
+     * Test the exists() method with plugin-prefixed models.
+     *
+     * @return void
+     */
+    public function testExistsPlugin()
+    {
+        $this->assertFalse($this->locator->exists('Comments'));
+        $this->assertFalse($this->locator->exists('TestPlugin.Comments'));
+
+        $this->locator->get('TestPlugin.Comments', ['name' => 'comments']);
+        $this->assertFalse($this->locator->exists('Comments'), 'The Comments key should not be populated');
+        $this->assertTrue($this->locator->exists('TestPlugin.Comments'), 'The plugin.alias key should now be populated');
+    }
+
+    /**
+     * Test getting instances from the registry.
+     *
+     * @return void
+     */
+    public function testGet()
+    {
+        $result = $this->locator->get(
+            'Articles',
+            [
+                'name' => 'my_articles',
+            ]
+        );
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('my_articles', $result->getName());
+
+        $result2 = $this->locator->get('Articles');
+        $this->assertSame($result, $result2);
+        $this->assertSame('my_articles', $result->getName());
+    }
+
+    /**
+     * Are auto-models instanciated correctly? How about when they have an alias?
+     *
+     * @return void
+     */
+    public function testGetFallbacks()
+    {
+        $result = $this->locator->get('Droids');
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('droids', $result->getName());
+
+        $result = $this->locator->get('R2D2', ['className' => 'Droids']);
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame(
+            'r2_d2',
+            $result->getName(),
+            'The name should be derived from the alias'
+        );
+
+        $result = $this->locator->get(
+            'C3P0',
+            ['className' => 'Droids', 'name' => 'droids']
+        );
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('droids', $result->getName(), 'The name should be taken from options');
+
+        $result = $this->locator->get('Funky.Chipmunks');
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('chipmunks', $result->getName(), 'The name should be derived from the alias');
+
+        $result = $this->locator->get('Awesome', ['className' => 'Funky.Monkies']);
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('awesome', $result->getName(), 'The name should be derived from the alias');
+
+        $result = $this->locator->get('Stuff', ['className' => 'Cake\ElasticSearch\Index']);
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
+        $this->assertSame('stuff', $result->getName(), 'The name should be derived from the alias');
+    }
+
+    /**
+     * Test get with config throws an exception if the alias exists already.
+     *
+     * @return                   void
+     */
+    public function testGetExistingWithConfigData()
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('You cannot configure "Users", it already exists in the registry.');
+        $users = $this->locator->get('Users');
+        $this->locator->get('Users', ['name' => 'my_users']);
+    }
+
+    /**
+     * Test get() can be called several times with the same option without
+     * throwing an exception.
+     *
+     * @return void
+     */
+    public function testGetWithSameOption()
+    {
+        $result = $this->locator->get('Users', ['className' => MyUsersIndex::class]);
+        $result2 = $this->locator->get('Users', ['className' => MyUsersIndex::class]);
+        $this->assertEquals($result, $result2);
+    }
+
+    /**
+     * Test get() with plugin syntax aliases
+     *
+     * @return void
+     */
+    public function testGetPlugin()
+    {
+        $this->loadPlugins(['TestPlugin']);
+        $table = $this->locator->get('TestPlugin.Comments');
+
+        $this->assertInstanceOf('TestPlugin\Model\Index\CommentsIndex', $table);
+        $this->assertFalse(
+            $this->locator->exists('Comments'),
+            'Short form should NOT exist'
+        );
+        $this->assertTrue(
+            $this->locator->exists('TestPlugin.Comments'),
+            'Long form should exist'
+        );
+
+        $second = $this->locator->get('TestPlugin.Comments');
+        $this->assertSame($table, $second, 'Can fetch long form');
+    }
+
+    /**
+     * Test get() with same-alias models in different plugins
+     *
+     * There should be no internal cache-confusion
+     *
+     * @return void
+     */
+    public function testGetMultiplePlugins()
+    {
+        $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+
+        $app = $this->locator->get('Comments');
+        $plugin1 = $this->locator->get('TestPlugin.Comments');
+        $plugin2 = $this->locator->get('TestPluginTwo.Comments');
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $app, 'Should be a generic instance');
+        $this->assertInstanceOf('TestPlugin\Model\Index\CommentsIndex', $plugin1, 'Should be a concrete class');
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $plugin2, 'Should be a plugin 2 generic instance');
+
+        $plugin2 = $this->locator->get('TestPluginTwo.Comments');
+        $plugin1 = $this->locator->get('TestPlugin.Comments');
+        $app = $this->locator->get('Comments');
+
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $app, 'Should still be a generic instance');
+        $this->assertInstanceOf('TestPlugin\Model\Index\CommentsIndex', $plugin1, 'Should still be a concrete class');
+        $this->assertInstanceOf('Cake\ElasticSearch\Index', $plugin2, 'Should still be a plugin 2 generic instance');
+    }
+
+    /**
+     * Test get() with plugin aliases + className option.
+     *
+     * @return void
+     */
+    public function testGetPluginWithClassNameOption()
+    {
+        $this->loadPlugins(['TestPlugin']);
+        $table = $this->locator->get(
+            'MyComments',
+            [
+            'className' => 'TestPlugin.Comments',
+            ]
+        );
+        $class = 'TestPlugin\Model\Index\CommentsIndex';
+        $this->assertInstanceOf($class, $table);
+        $this->assertFalse($this->locator->exists('Comments'), 'Class name should not exist');
+        $this->assertFalse($this->locator->exists('TestPlugin.Comments'), 'Full class alias should not exist');
+        $this->assertTrue($this->locator->exists('MyComments'), 'Class name should exist');
+
+        $second = $this->locator->get('MyComments');
+        $this->assertSame($table, $second);
+    }
+
+    /**
+     * Test get() with full namespaced classname
+     *
+     * @return void
+     */
+    public function testGetPluginWithFullNamespaceName()
+    {
+        $this->loadPlugins(['TestPlugin']);
+        $class = 'TestPlugin\Model\Index\CommentsIndex';
+        $table = $this->locator->get(
+            'Comments',
+            ['className' => $class]
+        );
+        $this->assertInstanceOf($class, $table);
+        $this->assertFalse($this->locator->exists('TestPlugin.Comments'), 'Full class alias should not exist');
+        $this->assertTrue($this->locator->exists('Comments'), 'Class name should exist');
+    }
+
+    /**
+     * Test setting an instance.
+     *
+     * @return void
+     */
+    public function testSet()
+    {
+        $mock = $this->getMockBuilder('Cake\ElasticSearch\Index')->getMock();
+        $this->assertSame($mock, $this->locator->set('Articles', $mock));
+        $this->assertSame($mock, $this->locator->get('Articles'));
+    }
+
+    /**
+     * Test setting an instance with plugin syntax aliases
+     *
+     * @return void
+     */
+    public function testSetPlugin()
+    {
+        $this->loadPlugins(['TestPlugin']);
+
+        $mock = $this->getMockBuilder('TestPlugin\Model\Index\CommentsIndex')
+            ->getMock();
+
+        $this->assertSame($mock, $this->locator->set('TestPlugin.Comments', $mock));
+        $this->assertSame($mock, $this->locator->get('TestPlugin.Comments'));
+    }
+
+    /**
+     * Tests remove an instance
+     *
+     * @return void
+     */
+    public function testRemove()
+    {
+        $first = $this->locator->get('Comments');
+
+        $this->assertTrue($this->locator->exists('Comments'));
+
+        $this->locator->remove('Comments');
+        $this->assertFalse($this->locator->exists('Comments'));
+
+        $second = $this->locator->get('Comments');
+
+        $this->assertNotSame(
+            $first,
+            $second,
+            'Should be different, as the reference to the first was destroyed'
+        );
+        $this->assertTrue($this->locator->exists('Comments'));
+    }
+
+    /**
+     * testRemovePlugin
+     *
+     * Removing a plugin-prefixed model should not affect any other
+     * plugin-prefixed model, or app model.
+     * Removing an app model should not affect any other
+     * plugin-prefixed model.
+     *
+     * @return void
+     */
+    public function testRemovePlugin()
+    {
+        $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
+
+        $app = $this->locator->get('Comments');
+        $this->locator->get('TestPlugin.Comments');
+        $plugin = $this->locator->get('TestPluginTwo.Comments');
+
+        $this->assertTrue($this->locator->exists('Comments'));
+        $this->assertTrue($this->locator->exists('TestPlugin.Comments'));
+        $this->assertTrue($this->locator->exists('TestPluginTwo.Comments'));
+
+        $this->locator->remove('TestPlugin.Comments');
+
+        $this->assertTrue($this->locator->exists('Comments'));
+        $this->assertFalse($this->locator->exists('TestPlugin.Comments'));
+        $this->assertTrue($this->locator->exists('TestPluginTwo.Comments'));
+
+        $app2 = $this->locator->get('Comments');
+        $plugin2 = $this->locator->get('TestPluginTwo.Comments');
+
+        $this->assertSame($app, $app2, 'Should be the same Comments object');
+        $this->assertSame($plugin, $plugin2, 'Should be the same TestPluginTwo.Comments object');
+
+        $this->locator->remove('Comments');
+
+        $this->assertFalse($this->locator->exists('Comments'));
+        $this->assertFalse($this->locator->exists('TestPlugin.Comments'));
+        $this->assertTrue($this->locator->exists('TestPluginTwo.Comments'));
+
+        $plugin3 = $this->locator->get('TestPluginTwo.Comments');
+
+        $this->assertSame($plugin, $plugin3, 'Should be the same TestPluginTwo.Comments object');
+    }
+
+    public function testSetFallbackClassName(): void
+    {
+        $this->locator->setFallbackClassName('TestApp\Model\Index\UsersIndex');
+
+        $result = $this->locator->get('Droids');
+        $this->assertInstanceOf('TestApp\Model\Index\UsersIndex', $result);
+
+        $this->locator->setFallbackClassName(Index::class);
+    }
+}

--- a/tests/TestCase/Datasource/IndexLocatorTest.php
+++ b/tests/TestCase/Datasource/IndexLocatorTest.php
@@ -17,11 +17,9 @@ declare(strict_types=1);
 namespace Cake\ElasticSearch\Test\TestCase\Datasource;
 
 use Cake\Core\Configure;
-use Cake\ElasticSearch\Index;
 use Cake\ElasticSearch\Datasource\IndexLocator;
 use Cake\ElasticSearch\Exception\MissingIndexClassException;
-
-;
+use Cake\ElasticSearch\Index;
 use Cake\TestSuite\TestCase;
 
 /**

--- a/tests/TestCase/Datasource/IndexLocatorTest.php
+++ b/tests/TestCase/Datasource/IndexLocatorTest.php
@@ -18,7 +18,10 @@ namespace Cake\ElasticSearch\Test\TestCase\Datasource;
 
 use Cake\Core\Configure;
 use Cake\ElasticSearch\Index;
-use Cake\ElasticSearch\Datasource\IndexLocator;;
+use Cake\ElasticSearch\Datasource\IndexLocator;
+use Cake\ElasticSearch\Exception\MissingIndexClassException;
+
+;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -125,6 +128,18 @@ class IndexLocatorTest extends TestCase
         $result = $this->locator->get('Stuff', ['className' => 'Cake\ElasticSearch\Index']);
         $this->assertInstanceOf('Cake\ElasticSearch\Index', $result);
         $this->assertSame('stuff', $result->getName(), 'The name should be derived from the alias');
+    }
+
+    /**
+     * Test get() with fallbacks disabled
+     *
+     * @return void
+     */
+    public function testGetNoFallback()
+    {
+        $this->locator->allowFallbackClass(false);
+        $this->expectException(MissingIndexClassException::class);
+        $this->locator->get('Articles');
     }
 
     /**


### PR DESCRIPTION
Implement the `LocatorInterface` for this plugin. This has lead to `IndexRegisty` being deprecated as we can use the locator internally instead.

I've backported the docker-compose environment because I needed it for these changes too.

Fixes #288