### PR TITLE
fix: Error Messages Not Displayed for Nested Array Fields in Form Inputs

### DIFF
--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -421,7 +421,7 @@ class DocumentContext implements ContextInterface
             $errors = $entity->getError(array_pop($parts));
         }
 
-        if (!$errors && $entityErrors && !is_array($entity)) {
+        if (!$errors && $entityErrors) {
             $errors = Hash::extract($entityErrors, $field) ?: [];
         }
 

--- a/src/View/Form/DocumentContext.php
+++ b/src/View/Form/DocumentContext.php
@@ -417,11 +417,20 @@ class DocumentContext implements ContextInterface
             $entityErrors = $this->_context['entity']->getErrors();
         }
 
+        $tailField = array_pop($parts);
         if ($entity instanceof Document) {
-            $errors = $entity->getError(array_pop($parts));
+            $errors = $entity->getError($tailField);
         }
 
-        if (!$errors && $entityErrors) {
+        // If errors couldn't be read from $entity and $entity
+        // is either not an array, or the tail field is not Document
+        // we want to extract errors from the root entity as we could
+        // have nested validators, or structured fields.
+        if (
+            !$errors &&
+            $entityErrors &&
+            (!is_array($entity) || !($entity[$tailField] instanceof Document))
+        ) {
             $errors = Hash::extract($entityErrors, $field) ?: [];
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,8 +51,8 @@ if (!getenv('DB_URL')) {
     putenv('DB_URL=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection');
 }
 
-ConnectionManager::setConfig('elastic', ['url' => getenv('DB_URL')]);
 ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
+ConnectionManager::setConfig('test_elastic', ['url' => getenv('DB_URL')]);
 
 $schema = new MappingGenerator('./tests/mappings.php', 'test');
 $schema->reload();


### PR DESCRIPTION
https://github.com/cakephp/elastic-search/issues/323