### PR TITLE
adjust ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           --health-retries 10
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -106,6 +108,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I ran https://github.com/woodruffw/zizmor on the current CI config and got the following output:
```
🌈 completed ci.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/elastic-search/.github/workflows/ci.yml:39:7
   |
39 |     - uses: actions/checkout@v2
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/kevin/Documents/CakePHP/Org/elastic-search/.github/workflows/ci.yml:108:7
    |
108 |     - uses: actions/checkout@v3
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> /Users/kevin/Documents/CakePHP/Org/elastic-search/.github/workflows/ci.yml:71:7
   |
71 |     - name: Setup problem matchers for PHPUnit
   |       ---------------------------------------- info: this step
72 |       if: matrix.php-version == '8.1'
73 |       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
   |       ---------------------------------------------------------------- info: runner.tool_cache may expand into attacker-controllable code
   |
   = note: audit confidence → Low

13 findings (10 suppressed): 0 unknown, 1 informational, 0 low, 2 medium, 0 high
```