### PR TITLE
328 Update docs, use FactoryLocator::get('ElasticSearch')

### DIFF
--- a/docs/en/4-0-upgrade-guide.rst
+++ b/docs/en/4-0-upgrade-guide.rst
@@ -27,11 +27,8 @@ use Cake\ElasticSearch\IndexRegistry;
 $articles = IndexRegistry::get('Articles');
 ```
 
-Change to:
+Change to::
 
+    use Cake\Datasource\FactoryLocator;
 
-```php
-use Cake\Datasource\FactoryLocator;
-
-$articles = FactoryLocator::get('ElasticSearch')->get('Articles');
-```
+    $articles = FactoryLocator::get('ElasticSearch')->get('Articles');

--- a/docs/en/4-0-upgrade-guide.rst
+++ b/docs/en/4-0-upgrade-guide.rst
@@ -17,7 +17,7 @@ Breaking Changes
 
 
 Indexes
-================
+======
 
 IndexRegistry has been deprecated.
 

--- a/docs/en/4-0-upgrade-guide.rst
+++ b/docs/en/4-0-upgrade-guide.rst
@@ -21,13 +21,14 @@ Indexes
 
 IndexRegistry has been deprecated.
 
-```php
-use Cake\ElasticSearch\IndexRegistry;
+Old code example::
 
-$articles = IndexRegistry::get('Articles');
-```
+    use Cake\ElasticSearch\IndexRegistry;
 
-Change to::
+    $articles = IndexRegistry::get('Articles');
+
+
+New code example::
 
     use Cake\Datasource\FactoryLocator;
 

--- a/docs/en/4-0-upgrade-guide.rst
+++ b/docs/en/4-0-upgrade-guide.rst
@@ -14,3 +14,24 @@ Breaking Changes
 * ``Query::isEagerLoaded()``, and ``Query::eagerLoaded()`` were removed.
   Previously these methods were inherited from ``QueryTrait`` but served no
   purpose here.
+
+
+Indexes
+================
+
+IndexRegistry has been deprecated.
+
+```php
+use Cake\ElasticSearch\IndexRegistry;
+
+$articles = IndexRegistry::get('Articles');
+```
+
+Change to:
+
+
+```php
+use Cake\Datasource\FactoryLocator;
+
+$articles = FactoryLocator::get('ElasticSearch')->get('Articles');
+```


### PR DESCRIPTION
Update docs for CakePHP5 usage.