### PR TITLE
Add support for complex mappings in MappingGenerator

### DIFF
--- a/src/TestSuite/Fixture/MappingGenerator.php
+++ b/src/TestSuite/Fixture/MappingGenerator.php
@@ -13,16 +13,38 @@ use RuntimeException;
  * Index definition files should return an array of indexes
  * to create. Each index in the array should follow the form of
  *
+ * Simple mapping (properties only):
  * ```
  * [
  *   'name' => 'articles',
- *   'mapping' => [...],
+ *   'mapping' => [
+ *     'title' => ['type' => 'text'],
+ *     'body' => ['type' => 'text'],
+ *   ],
+ *   'settings' => [...],
+ * ]
+ * ```
+ *
+ * Full mapping structure (with dynamic_templates, etc.):
+ * ```
+ * [
+ *   'name' => 'articles',
+ *   'mapping' => [
+ *     'properties' => [
+ *       'title' => ['type' => 'text'],
+ *       'body' => ['type' => 'text'],
+ *     ],
+ *     'dynamic_templates' => [...],
+ *     'dynamic' => 'strict',
+ *   ],
  *   'settings' => [...],
  * ]
  * ```
  *
  * The `mapping` key should be compatible with Elasticsearch's
- * mapping API and Elastica.
+ * mapping API and Elastica. If the mapping contains a 'properties'
+ * key, it will be treated as a full mapping structure. Otherwise,
+ * it will be wrapped in a 'properties' key for backward compatibility.
  *
  * The `settings` key can contain Elastica compatible index creation
  * settings.
@@ -103,6 +125,12 @@ class MappingGenerator
     /**
      * Create an index.
      *
+     * Supports two mapping formats:
+     * - Simple: Direct property definitions (wrapped in 'properties' automatically)
+     * - Full: Complete mapping structure including 'properties', 'dynamic_templates', etc.
+     *
+     * The format is detected by checking if the mapping contains a 'properties' key.
+     *
      * @param \Cake\ElasticSearch\Datasource\Connection $db The connection.
      * @param array $mapping The index mapping and settings.
      */
@@ -119,11 +147,17 @@ class MappingGenerator
             $args['settings'] = $mapping['settings'];
         }
 
-        // In Elastica, mappings should be included in index creation
+        // Detect if this is a full mapping structure or simple properties
         if (!empty($mapping['mapping'])) {
-            $args['mappings'] = [
-                'properties' => $mapping['mapping'],
-            ];
+            if (isset($mapping['mapping']['properties'])) {
+                // Full mapping structure - use as-is to support dynamic_templates, etc.
+                $args['mappings'] = $mapping['mapping'];
+            } else {
+                // Simple properties only - wrap for backward compatibility
+                $args['mappings'] = [
+                    'properties' => $mapping['mapping'],
+                ];
+            }
         }
 
         $response = $esIndex->create($args);

--- a/tests/TestCase/TestSuite/Fixture/MappingGeneratorTest.php
+++ b/tests/TestCase/TestSuite/Fixture/MappingGeneratorTest.php
@@ -333,6 +333,172 @@ class MappingGeneratorTest extends TestCase
     }
 
     /**
+     * Test simple mapping format (backward compatibility)
+     */
+    public function testSimpleMappingFormat(): void
+    {
+        $file = $this->createMappingFile([
+            [
+                'name' => 'test_index_1',
+                'mapping' => [
+                    'id' => ['type' => 'integer'],
+                    'title' => ['type' => 'text'],
+                    'body' => ['type' => 'text'],
+                ],
+            ],
+        ]);
+
+        $generator = new MappingGenerator($file, 'test');
+        $generator->reload(['test_index_1']);
+
+        $index = $this->connection->getIndex('test_index_1');
+        $this->assertTrue($index->exists());
+
+        // Verify mapping was created correctly
+        $mapping = $index->getMapping();
+        $this->assertNotEmpty($mapping);
+        $this->assertArrayHasKey('properties', $mapping);
+
+        $properties = $mapping['properties'];
+        $this->assertArrayHasKey('id', $properties);
+        $this->assertArrayHasKey('title', $properties);
+        $this->assertArrayHasKey('body', $properties);
+
+        unlink($file);
+    }
+
+    /**
+     * Test full mapping format with properties key
+     */
+    public function testFullMappingFormatWithProperties(): void
+    {
+        $file = $this->createMappingFile([
+            [
+                'name' => 'test_index_1',
+                'mapping' => [
+                    'properties' => [
+                        'id' => ['type' => 'integer'],
+                        'title' => ['type' => 'text'],
+                        'body' => ['type' => 'text'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $generator = new MappingGenerator($file, 'test');
+        $generator->reload(['test_index_1']);
+
+        $index = $this->connection->getIndex('test_index_1');
+        $this->assertTrue($index->exists());
+
+        // Verify mapping was created correctly
+        $mapping = $index->getMapping();
+        $this->assertNotEmpty($mapping);
+        $this->assertArrayHasKey('properties', $mapping);
+
+        $properties = $mapping['properties'];
+        $this->assertArrayHasKey('id', $properties);
+        $this->assertArrayHasKey('title', $properties);
+        $this->assertArrayHasKey('body', $properties);
+
+        unlink($file);
+    }
+
+    /**
+     * Test full mapping format with dynamic_templates
+     */
+    public function testFullMappingFormatWithDynamicTemplates(): void
+    {
+        $file = $this->createMappingFile([
+            [
+                'name' => 'test_index_1',
+                'mapping' => [
+                    'properties' => [
+                        'id' => ['type' => 'integer'],
+                        'title' => ['type' => 'text'],
+                    ],
+                    'dynamic_templates' => [
+                        [
+                            'strings_as_keywords' => [
+                                'match_mapping_type' => 'string',
+                                'mapping' => [
+                                    'type' => 'keyword',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $generator = new MappingGenerator($file, 'test');
+        $generator->reload(['test_index_1']);
+
+        $index = $this->connection->getIndex('test_index_1');
+        $this->assertTrue($index->exists());
+
+        // Verify mapping was created with dynamic_templates
+        $mapping = $index->getMapping();
+        $this->assertNotEmpty($mapping);
+        $this->assertArrayHasKey('properties', $mapping);
+        $this->assertArrayHasKey('dynamic_templates', $mapping);
+
+        $dynamicTemplates = $mapping['dynamic_templates'];
+        $this->assertCount(1, $dynamicTemplates);
+        $this->assertArrayHasKey('strings_as_keywords', $dynamicTemplates[0]);
+
+        unlink($file);
+    }
+
+    /**
+     * Test mixing simple and full mapping formats in same file
+     */
+    public function testMixedMappingFormats(): void
+    {
+        $file = $this->createMappingFile([
+            [
+                'name' => 'test_index_1',
+                'mapping' => [
+                    'id' => ['type' => 'integer'],
+                    'title' => ['type' => 'text'],
+                ],
+            ],
+            [
+                'name' => 'test_index_2',
+                'mapping' => [
+                    'properties' => [
+                        'id' => ['type' => 'integer'],
+                        'name' => ['type' => 'text'],
+                    ],
+                    'dynamic' => 'strict',
+                ],
+            ],
+        ]);
+
+        $generator = new MappingGenerator($file, 'test');
+        $generator->reload();
+
+        $index1 = $this->connection->getIndex('test_index_1');
+        $index2 = $this->connection->getIndex('test_index_2');
+
+        $this->assertTrue($index1->exists());
+        $this->assertTrue($index2->exists());
+
+        // Verify both mappings were created correctly
+        $mapping1 = $index1->getMapping();
+        $mapping2 = $index2->getMapping();
+
+        $this->assertNotEmpty($mapping1);
+        $this->assertNotEmpty($mapping2);
+
+        $this->assertArrayHasKey('properties', $mapping1);
+        $this->assertArrayHasKey('properties', $mapping2);
+        $this->assertArrayHasKey('dynamic', $mapping2);
+
+        unlink($file);
+    }
+
+    /**
      * Helper method to create a temporary mapping file
      *
      * @param array $mappings The mappings to write to the file


### PR DESCRIPTION
Extends `MappingGenerator` to support full Elasticsearch mapping structures, enabling the use of advanced features like `dynamic_templates`, `dynamic` settings, and other mapping-level configurations.

### Motivation
Previously, `MappingGenerator` only supported simple property definitions, automatically wrapping them in a `properties` key. This prevented users from utilizing advanced Elasticsearch mapping features that need to be defined at the mapping root level, such as `dynamic_templates`.

### Changes

**Detection Logic**: The method now detects whether the mapping contains a `properties` key:
- **If present**: Treats it as a full mapping structure and uses it as-is
- **If absent**: Maintains backward compatibility by wrapping in `properties`

**Example Usage**:

```php
// Simple format (backward compatible)
[
    'name' => 'articles',
    'mapping' => [
        'title' => ['type' => 'text'],
        'body' => ['type' => 'text']
    ]
]

// Advanced format (new)
[
    'name' => 'articles',
    'mapping' => [
        'properties' => [
            'title' => ['type' => 'text'],
            'body' => ['type' => 'text']
        ],
        'dynamic_templates' => [
            [
                'strings_as_keywords' => [
                    'match_mapping_type' => 'string',
                    'mapping' => ['type' => 'keyword']
                ]
            ]
        ],
        'dynamic' => 'strict'
    ]
]