### PR TITLE
Make ResultSet serializable so cached queries can be executed

### DIFF
--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -237,6 +237,42 @@ class ResultSet extends IteratorIterator implements ResultSetInterface
     }
 
     /**
+     * Returns the state to be serialized, so result sets can be stored in a cache (without elastica handles)
+     *
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            'resultSet' => $this->resultSet,
+            'entityClass' => $this->entityClass,
+            'embeds' => $this->embeds,
+            'repoName' => $this->repoName,
+        ];
+    }
+
+    /**
+     * Restores a result set from its serialized state
+     *
+     * @param array<string, mixed> $data The state as returned by __serialize()
+     * @return void
+     */
+    public function __unserialize(array $data): void
+    {
+        assert($data['resultSet'] instanceof ElasticaResultSet);
+        assert(is_string($data['entityClass']));
+        assert(is_array($data['embeds']));
+        assert(is_string($data['repoName']));
+
+        $this->resultSet = $data['resultSet'];
+        $this->entityClass = $data['entityClass'];
+        $this->embeds = $data['embeds'];
+        $this->repoName = $data['repoName'];
+
+        parent::__construct($this->resultSet);
+    }
+
+    /**
      * Debug output hook method.
      */
     public function __debugInfo(): array

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -696,11 +696,16 @@ class QueryTest extends TestCase
         ]);
 
         $index = $this->getIndex();
-        $query = new Query($index);
 
-        $results = $query->limit(1)->cache('test_key', 'query_cache')->all();
-        $cached = $query->limit(1)->cache('test_key', 'query_cache')->all();
+        $results = (new Query($index))->limit(1)->cache('test_key', 'query_cache')->all();
+        $cached = (new Query($index))->limit(1)->cache('test_key', 'query_cache')->all();
         $this->assertEquals($results->toArray(), $cached->toArray());
+        $this->assertEquals($results->getTotalHits(), $cached->getTotalHits());
+        $this->assertEquals($results->getAggregations(), $cached->getAggregations());
+        $this->assertEquals($results->getSuggests(), $cached->getSuggests());
+        $this->assertEquals($results->getMaxScore(), $cached->getMaxScore());
+        $this->assertEquals($results->getTotalTime(), $cached->getTotalTime());
+        $this->assertEquals($results->hasTimedOut(), $cached->hasTimedOut());
     }
 
     /**

--- a/tests/TestCase/QueryTest.php
+++ b/tests/TestCase/QueryTest.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Cake\ElasticSearch\Test\TestCase;
 
 use AssertionError;
+use Cake\Cache\Cache;
+use Cake\Cache\Engine\FileEngine;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\RepositoryInterface;
@@ -680,6 +682,25 @@ class QueryTest extends TestCase
         // Test disabling cache
         $result = $query->cache(false);
         $this->assertSame($query, $result);
+    }
+
+    /**
+     * Test that a cached query stores its results when it is executed and reads them back on the next execution
+     */
+    public function testCacheMethodWithExecutedQuery(): void
+    {
+        Cache::setConfig('query_cache', [
+            'className' => FileEngine::class,
+            'path' => sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'query_cache' . DIRECTORY_SEPARATOR,
+            'duration' => '1 second',
+        ]);
+
+        $index = $this->getIndex();
+        $query = new Query($index);
+
+        $results = $query->limit(1)->cache('test_key', 'query_cache')->all();
+        $cached = $query->limit(1)->cache('test_key', 'query_cache')->all();
+        $this->assertEquals($results->toArray(), $cached->toArray());
     }
 
     /**


### PR DESCRIPTION
Calling Query::cache() and then executing the query always threw _"Serialization of 'CurlHandle' is not allowed"_, which made query result caching unusable with FileEngine.

  Query::all() hands the decorated ResultSet to QueryCacher::store(), and ResultSet keeps the query that produced it in $queryObject. From there the whole connection is reachable:

      ResultSet::$queryObject      -> Query
      Query::$_repository          -> Index
      Index::$_connection          -> Datasource\Connection
      Connection::$_client         -> Elastica\Client
      Elastica\Client::$_transport -> Transport
      Transport::$client           -> Transport\Client\Curl
      Curl::$curl                  -> CurlHandle

  Add __serialize()/__unserialize() that leave the query object out. 
  The decorated Elastica\ResultSet is kept whole rather than flattened to documents, so getTotalHits(), getAggregations(), getSuggests(), getMaxScore(), getTotalTime() and hasTimedOut() still answer correctly after a cache round trip. Since unserialize() does not run the constructor, __unserialize() calls parent::__construct() to set up the decorated iterator.
